### PR TITLE
refactor: separate data and HTML output into different directories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         GITHUB_USERNAME: ${{ inputs.username }}
         TIMEZONE: ${{ inputs.timezone }}
+        DATA_DIR: ./data
       run: npx github-weekly-reporter@${{ inputs.version }} daily-fetch
 
     - name: Weekly fetch (build full data from accumulated events)
@@ -79,6 +80,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         GITHUB_USERNAME: ${{ inputs.username }}
         TIMEZONE: ${{ inputs.timezone }}
+        DATA_DIR: ./data
       run: npx github-weekly-reporter@${{ inputs.version }} weekly-fetch
 
     - name: Generate AI content
@@ -92,6 +94,7 @@ runs:
         LLM_MODEL: ${{ inputs.llm-model }}
         LANGUAGE: ${{ inputs.language }}
         TIMEZONE: ${{ inputs.timezone }}
+        DATA_DIR: ./data
       run: |
         if [ -n "$LLM_PROVIDER" ] && [ -n "$LLM_MODEL" ]; then
           npx github-weekly-reporter@${{ inputs.version }} generate
@@ -105,6 +108,8 @@ runs:
       env:
         LANGUAGE: ${{ inputs.language }}
         TIMEZONE: ${{ inputs.timezone }}
+        DATA_DIR: ./data
+        OUTPUT_DIR: ./output
       run: npx github-weekly-reporter@${{ inputs.version }} render --theme ${{ inputs.theme }}
 
     - name: Deploy to GitHub Pages
@@ -113,4 +118,5 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
+        OUTPUT_DIR: ./output
       run: npx github-weekly-reporter@${{ inputs.version }} deploy

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -51,7 +51,7 @@ export const registerDeploy = (program: Command): void => {
   program
     .command("deploy")
     .description("Deploy generated report to GitHub Pages (gh-pages branch)")
-    .option("-d, --directory <dir>", "Directory containing generated report files (env: OUTPUT_DIR, default: ./report)")
+    .option("-d, --directory <dir>", "Directory containing generated HTML files (env: OUTPUT_DIR, default: ./output)")
     .option("-r, --repo <slug>", "Repository (owner/repo or full URL, env: GITHUB_REPOSITORY)")
     .option("--timezone <tz>", "IANA timezone (env: TIMEZONE, default: UTC)")
     .action(async (opts) => {
@@ -59,7 +59,7 @@ export const registerDeploy = (program: Command): void => {
         const timezone = opts.timezone ?? env("TIMEZONE") ?? "UTC";
         const repoUrl = buildRepoUrl(opts.repo);
         await run({
-          directory: opts.directory ?? env("OUTPUT_DIR") ?? "./report",
+          directory: opts.directory ?? env("OUTPUT_DIR") ?? "./output",
           repoUrl,
           timezone,
         });

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -18,7 +18,7 @@ const env = (key: string): string | undefined => process.env[key];
 type BaseOptions = {
   token: string;
   username: string;
-  output: string;
+  dataDir: string;
   timezone: string;
   date?: Date;
 };
@@ -32,7 +32,7 @@ const resolveBaseOptions = (
   if (!username) throw new Error("GitHub username required. Pass --username or set GITHUB_USERNAME.");
   const date = cli.date ? new Date(cli.date + "T12:00:00Z") : undefined;
   const timezone = cli.timezone ?? env("TIMEZONE") ?? "UTC";
-  return { token, username, output: cli.output ?? env("OUTPUT_DIR") ?? "./report", date, timezone };
+  return { token, username, dataDir: cli.dataDir ?? env("DATA_DIR") ?? "./data", date, timezone };
 };
 
 const tryReadYaml = async <T>(path: string): Promise<T | null> => {
@@ -63,7 +63,7 @@ const extractPRRefs = (events: GitHubEvent[]): PRRef[] => {
 const runDailyFetch = async (options: BaseOptions): Promise<void> => {
   const weekId = getWeekId(options.date, options.timezone);
   const range = buildWeeklyRange(options.date, options.timezone);
-  const reportDir = join(options.output, weekId.path);
+  const reportDir = join(options.dataDir, weekId.path);
   await mkdir(reportDir, { recursive: true });
 
   console.log(`Fetching events for ${options.username} (${weekId.path})...`);
@@ -82,7 +82,7 @@ const runDailyFetch = async (options: BaseOptions): Promise<void> => {
 const runWeeklyFetch = async (options: BaseOptions): Promise<void> => {
   const weekId = getWeekId(options.date, options.timezone);
   const range = buildWeeklyRange(options.date, options.timezone);
-  const reportDir = join(options.output, weekId.path);
+  const reportDir = join(options.dataDir, weekId.path);
   await mkdir(reportDir, { recursive: true });
 
   // Load accumulated events
@@ -146,7 +146,7 @@ const baseOptions = (cmd: Command): Command =>
   cmd
     .option("-t, --token <token>", "GitHub token (env: GITHUB_TOKEN)")
     .option("-u, --username <username>", "GitHub username (env: GITHUB_USERNAME)")
-    .option("-o, --output <dir>", "Output directory (env: OUTPUT_DIR, default: ./report)")
+    .option("--data-dir <dir>", "Data directory (env: DATA_DIR, default: ./data)")
     .option("--timezone <tz>", "IANA timezone (env: TIMEZONE, default: UTC)")
     .option("--date <date>", "Date within the target week (YYYY-MM-DD, default: today)");
 

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -11,7 +11,7 @@ import type { WeeklyReportData, LLMProvider, Language } from "../../types.js";
 const env = (key: string): string | undefined => process.env[key];
 
 type GenerateOptions = {
-  output: string;
+  dataDir: string;
   llmProvider: LLMProvider;
   llmApiKey: string;
   llmModel: string;
@@ -40,7 +40,7 @@ const resolveOptions = (
   const timezone = cli.timezone ?? env("TIMEZONE") ?? "UTC";
 
   return {
-    output: cli.output ?? env("OUTPUT_DIR") ?? "./report",
+    dataDir: cli.dataDir ?? env("DATA_DIR") ?? "./data",
     llmProvider,
     llmApiKey,
     llmModel,
@@ -52,8 +52,8 @@ const resolveOptions = (
 
 const run = async (options: GenerateOptions): Promise<void> => {
   const weekId = getWeekId(options.date, options.timezone);
-  const reportDir = join(options.output, weekId.path);
-  const dataPath = join(reportDir, "github-data.yaml");
+  const dataDir = join(options.dataDir, weekId.path);
+  const dataPath = join(dataDir, "github-data.yaml");
 
   console.log(`Reading ${dataPath}...`);
   const raw = await readFile(dataPath, "utf-8");
@@ -75,7 +75,7 @@ const run = async (options: GenerateOptions): Promise<void> => {
     process.exit(1);
   }
 
-  const llmDataPath = join(reportDir, "llm-data.yaml");
+  const llmDataPath = join(dataDir, "llm-data.yaml");
   await writeFile(llmDataPath, toYaml(aiContent, { lineWidth: 120 }), "utf-8");
   console.log(`LLM data written to ${llmDataPath}`);
 };
@@ -84,7 +84,7 @@ export const registerGenerate = (program: Command): void => {
   program
     .command("generate")
     .description("Generate AI content from fetched GitHub data")
-    .option("-o, --output <dir>", "Output directory (env: OUTPUT_DIR, default: ./report)")
+    .option("--data-dir <dir>", "Data directory (env: DATA_DIR, default: ./data)")
     .option("--llm-provider <provider>", "LLM provider (env: LLM_PROVIDER)")
     .option("--llm-api-key <key>", "LLM API key (env: OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY)")
     .option("--llm-model <model>", "LLM model name (env: LLM_MODEL)")

--- a/src/cli/commands/render.ts
+++ b/src/cli/commands/render.ts
@@ -1,7 +1,7 @@
 // render command: read github-data.yaml + llm-data.yaml and produce HTML
 
 import { Command } from "commander";
-import { readFile, writeFile, readdir } from "node:fs/promises";
+import { readFile, writeFile, readdir, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { renderReport } from "../../renderer/index.js";
@@ -12,7 +12,8 @@ import type { WeeklyReportData, AIContent, Theme, Language } from "../../types.j
 const env = (key: string): string | undefined => process.env[key];
 
 type RenderOptions = {
-  output: string;
+  dataDir: string;
+  outputDir: string;
   theme: Theme;
   language: Language;
   timezone: string;
@@ -46,21 +47,22 @@ const tryReadYaml = async <T>(path: string): Promise<T | null> => {
 };
 
 const buildReportEntries = async (
-  outputDir: string,
+  dataDir: string,
   reportPaths: string[],
 ): Promise<ReportEntry[]> =>
   Promise.all(
     reportPaths.map(async (path) => {
-      const llmData = await tryReadYaml<AIContent>(join(outputDir, path, "llm-data.yaml"));
+      const llmData = await tryReadYaml<AIContent>(join(dataDir, path, "llm-data.yaml"));
       return buildReportEntry(path, llmData?.title);
     }),
   );
 
 const run = async (options: RenderOptions): Promise<void> => {
   const weekId = getWeekId(options.date, options.timezone);
-  const reportDir = join(options.output, weekId.path);
+  const dataWeekDir = join(options.dataDir, weekId.path);
+  const outputWeekDir = join(options.outputDir, weekId.path);
 
-  const githubDataPath = join(reportDir, "github-data.yaml");
+  const githubDataPath = join(dataWeekDir, "github-data.yaml");
   console.log(`Reading ${githubDataPath}...`);
   const githubData = await tryReadYaml<WeeklyReportData>(githubDataPath);
   if (!githubData) {
@@ -68,7 +70,7 @@ const run = async (options: RenderOptions): Promise<void> => {
     process.exit(1);
   }
 
-  const llmDataPath = join(reportDir, "llm-data.yaml");
+  const llmDataPath = join(dataWeekDir, "llm-data.yaml");
   const aiContent = await tryReadYaml<AIContent>(llmDataPath);
   if (aiContent) {
     console.log("Loaded LLM data.");
@@ -85,21 +87,23 @@ const run = async (options: RenderOptions): Promise<void> => {
     timezone: options.timezone,
   });
 
-  const reportPath = join(reportDir, "index.html");
+  await mkdir(outputWeekDir, { recursive: true });
+  const reportPath = join(outputWeekDir, "index.html");
   await writeFile(reportPath, html, "utf-8");
   console.log(`Report written to ${reportPath}`);
 
   // Write index page with titles from each week's LLM data
-  const allPaths = await listReportDirs(options.output);
+  const allPaths = await listReportDirs(options.dataDir);
   if (!allPaths.includes(weekId.path)) allPaths.push(weekId.path);
-  const entries = await buildReportEntries(options.output, allPaths);
+  const entries = await buildReportEntries(options.dataDir, allPaths);
   const indexHtml = renderIndexPage(
     entries,
     options.theme,
     { username: githubData.username, avatarUrl: githubData.avatarUrl },
     options.language,
   );
-  const indexPath = join(options.output, "index.html");
+  const indexPath = join(options.outputDir, "index.html");
+  await mkdir(options.outputDir, { recursive: true });
   await writeFile(indexPath, indexHtml, "utf-8");
   console.log(`Index written to ${indexPath}`);
 };
@@ -108,7 +112,8 @@ export const registerRender = (program: Command): void => {
   program
     .command("render")
     .description("Render HTML report from fetched data and LLM content")
-    .option("-o, --output <dir>", "Output directory (env: OUTPUT_DIR, default: ./report)")
+    .option("--data-dir <dir>", "Data directory (env: DATA_DIR, default: ./data)")
+    .option("-o, --output-dir <dir>", "Output directory for HTML (env: OUTPUT_DIR, default: ./output)")
     .option("--theme <theme>", "Report theme (env: THEME, default: default)")
     .option("--language <lang>", "Report language: en, ja (env: LANGUAGE, default: en)")
     .option("--timezone <tz>", "IANA timezone (env: TIMEZONE, default: UTC)")
@@ -116,7 +121,8 @@ export const registerRender = (program: Command): void => {
     .action(async (opts) => {
       try {
         const options: RenderOptions = {
-          output: opts.output ?? env("OUTPUT_DIR") ?? "./report",
+          dataDir: opts.dataDir ?? env("DATA_DIR") ?? "./data",
+          outputDir: opts.outputDir ?? env("OUTPUT_DIR") ?? "./output",
           theme: (opts.theme ?? env("THEME") ?? "default") as Theme,
           language: (opts.language ?? env("LANGUAGE") ?? "en") as Language,
           timezone: opts.timezone ?? env("TIMEZONE") ?? "UTC",


### PR DESCRIPTION
## Summary

- Split the single `--output` directory into `--data-dir` and `--output-dir`
- Data files (YAML) and HTML output no longer share the same directory tree
- Deploy only pushes HTML, no YAML files go to gh-pages

## Directory structure

```
data/              (--data-dir / DATA_DIR)
  2026/W14/
    events.yaml
    github-data.yaml
    llm-data.yaml

output/            (--output-dir / OUTPUT_DIR)
  index.html
  2026/W14/
    index.html
```

## Changes by command

| Command | Before | After |
|---|---|---|
| `daily-fetch` | `--output` (./report) | `--data-dir` (./data) |
| `weekly-fetch` | `--output` (./report) | `--data-dir` (./data) |
| `generate` | `--output` (./report) | `--data-dir` (./data) |
| `render` | `--output` (./report) for both read/write | `--data-dir` (./data) for read, `--output-dir` (./output) for write |
| `deploy` | `--directory` (./report) | `--directory` (./output) |

## Environment variables

| Variable | Default | Used by |
|---|---|---|
| `DATA_DIR` | `./data` | fetch, generate, render |
| `OUTPUT_DIR` | `./output` | render, deploy |

Closes #34