### PR TITLE
feat: link author avatar and name to GitHub profile

### DIFF
--- a/src/renderer/templates/partials/header.hbs
+++ b/src/renderer/templates/partials/header.hbs
@@ -1,4 +1,8 @@
 <div class="header">
+  <a href="https://github.com/{{username}}" class="header-author" target="_blank" rel="noopener nofollow">
+    <img src="{{avatarUrl}}" alt="{{username}}" />
+    <span>{{username}}</span>
+  </a>
   <div class="header-week">{{weekLabel dateRange.from dateRange.to}}</div>
   <h1 class="header-title">{{#if aiContent}}{{aiContent.title}}{{else}}{{userWeek username}}{{/if}}</h1>
   {{#if aiContent}}<p class="header-sub">{{aiContent.subtitle}}</p>{{/if}}

--- a/src/renderer/templates/report.hbs
+++ b/src/renderer/templates/report.hbs
@@ -15,7 +15,7 @@
 <body>
 
 <nav>
-  <a href="https://github.com/{{username}}" class="nav-left" target="_blank" rel="noopener nofollow">
+  <a href="../../index.html" class="nav-left">
     <img src="{{avatarUrl}}" alt="{{username}}" />
     <span>{{username}}</span>
   </a>

--- a/src/renderer/themes.ts
+++ b/src/renderer/themes.ts
@@ -143,6 +143,22 @@ export const buildCSS = (theme: Theme, language: Language = "en"): string => {
 
     /* HEADER */
     .header { margin-bottom: 3rem; }
+    .header-author {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      text-decoration: none;
+      color: ${c.textSecondary};
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-bottom: 1rem;
+      transition: color 0.2s;
+    }
+    .header-author:hover { color: ${c.accent}; }
+    .header-author img {
+      width: 24px; height: 24px;
+      border-radius: 50%;
+    }
     .header-week {
       font-family: ${f.monoFamily};
       font-size: 0.75rem;


### PR DESCRIPTION
## Summary

- Link author avatar/name to `https://github.com/{username}` on both report and index pages
- All profile links open in new tab with `rel="noopener nofollow"`

## Changes

- **report.hbs**: nav avatar/name now links to GitHub profile (was linking to index page)
- **index-page.ts**: profile section changed from `<div>` to `<a>` linking to GitHub profile, with `text-decoration: none; color: inherit` to preserve existing style

## Not changed

- Back navigation (`← All Weeks`) still links to `../../index.html` (internal, same tab)
- Footer links unchanged (already working)

Closes #31