### PR TITLE
refactor: make LLM content required for report rendering

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,11 +43,11 @@ inputs:
     required: false
     default: ''
   llm-provider:
-    description: 'LLM provider (openai, anthropic, gemini)'
+    description: 'LLM provider (openai, anthropic, gemini). Required for weekly mode.'
     required: false
     default: ''
   llm-model:
-    description: 'LLM model name'
+    description: 'LLM model name. Required for weekly mode.'
     required: false
     default: ''
   date:
@@ -122,12 +122,7 @@ runs:
         LANGUAGE: ${{ inputs.language }}
         TIMEZONE: ${{ inputs.timezone }}
         DATA_DIR: ./data
-      run: |
-        if [ -n "$LLM_PROVIDER" ] && [ -n "$LLM_MODEL" ]; then
-          npx github-weekly-reporter@${{ inputs.version }} generate ${{ inputs.date && format('--date {0}', inputs.date) || '' }}
-        else
-          echo "No LLM provider configured, skipping AI content generation"
-        fi
+      run: npx github-weekly-reporter@${{ inputs.version }} generate ${{ inputs.date && format('--date {0}', inputs.date) || '' }}
 
     - name: Commit and push data (weekly)
       if: inputs.mode == 'weekly'

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -11,7 +11,7 @@ import { fetchContributions } from "../../collector/fetch-contributions.js";
 import { fetchPRsByRefs, type PRRef } from "../../collector/fetch-repo-prs.js";
 import { aggregateRepositories } from "../../collector/aggregate.js";
 import { getWeekId } from "../../deployer/week.js";
-import type { GitHubEvent, WeeklyReportData } from "../../types.js";
+import type { GitHubEvent } from "../../types.js";
 
 const env = (key: string): string | undefined => process.env[key];
 
@@ -108,7 +108,7 @@ const runWeeklyFetch = async (options: BaseOptions): Promise<void> => {
   const totalAdditions = pullRequests.reduce((sum, pr) => sum + pr.additions, 0);
   const totalDeletions = pullRequests.reduce((sum, pr) => sum + pr.deletions, 0);
 
-  const data: WeeklyReportData = {
+  const githubData = {
     username: contributions.username,
     avatarUrl: contributions.avatarUrl,
     dateRange: {
@@ -131,11 +131,7 @@ const runWeeklyFetch = async (options: BaseOptions): Promise<void> => {
     issues: [],
     events,
     externalContributions: [],
-    aiContent: null,
   };
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { aiContent: _, ...githubData } = data;
   const dataPath = join(reportDir, "github-data.yaml");
   await writeFile(dataPath, toYaml(githubData, { lineWidth: 120 }), "utf-8");
   console.log(`GitHub data written to ${dataPath}`);

--- a/src/cli/commands/render.ts
+++ b/src/cli/commands/render.ts
@@ -73,11 +73,11 @@ const run = async (options: RenderOptions): Promise<void> => {
 
   const llmDataPath = join(dataWeekDir, "llm-data.yaml");
   const aiContent = await tryReadYaml<AIContent>(llmDataPath);
-  if (aiContent) {
-    console.log("Loaded LLM data.");
-  } else {
-    console.log("No LLM data found. Rendering without AI content.");
+  if (!aiContent) {
+    console.error(`LLM data not found at ${llmDataPath}. Run 'generate' first.`);
+    process.exit(1);
   }
+  console.log("Loaded LLM data.");
 
   const data: WeeklyReportData = { ...githubData, aiContent };
 

--- a/src/renderer/renderer.test.ts
+++ b/src/renderer/renderer.test.ts
@@ -22,11 +22,6 @@ const MOCK_DATA: WeeklyReportData = {
   issues: [],
   events: [],
   externalContributions: [],
-  aiContent: null,
-};
-
-const MOCK_WITH_AI: WeeklyReportData = {
-  ...MOCK_DATA,
   aiContent: {
     title: "Auth refactor completed",
     subtitle: "A focused backend week",
@@ -71,8 +66,8 @@ describe("renderReport", () => {
     expect(html).toContain("2026-04-03");
   });
 
-  it("renders AI content when provided", () => {
-    const html = renderReport(MOCK_WITH_AI);
+  it("renders AI content", () => {
+    const html = renderReport(MOCK_DATA);
     expect(html).toContain("Auth refactor completed");
     expect(html).toContain("A focused backend week");
     expect(html).toContain("First paragraph about the week.");
@@ -80,7 +75,7 @@ describe("renderReport", () => {
   });
 
   it("renders summary sections", () => {
-    const html = renderReport(MOCK_WITH_AI);
+    const html = renderReport(MOCK_DATA);
     expect(html).toContain("Summary");
     expect(html).toContain("commit-summary");
     expect(html).toContain("47 commits");
@@ -88,7 +83,7 @@ describe("renderReport", () => {
   });
 
   it("renders highlight cards", () => {
-    const html = renderReport(MOCK_WITH_AI);
+    const html = renderReport(MOCK_DATA);
     expect(html).toContain("Highlights");
     expect(html).toContain("feat: add OAuth flow");
     expect(html).toContain("org/backend");
@@ -102,17 +97,9 @@ describe("renderReport", () => {
   });
 
   it("includes OG meta tags", () => {
-    const html = renderReport(MOCK_WITH_AI);
+    const html = renderReport(MOCK_DATA);
     expect(html).toContain("og:title");
     expect(html).toContain("Auth refactor completed");
-  });
-
-  it("omits AI sections when aiContent is null", () => {
-    const html = renderReport(MOCK_DATA);
-    const body = html.split("<body>")[1] ?? "";
-    expect(body).not.toContain("Summary");
-    expect(body).not.toContain("Highlights");
-    expect(body).not.toContain('class="overview"');
   });
 
   it("renders dark theme (string argument for backward compatibility)", () => {
@@ -128,7 +115,7 @@ describe("renderReport", () => {
   });
 
   it("renders Japanese locale", () => {
-    const html = renderReport(MOCK_WITH_AI, { language: "ja" });
+    const html = renderReport(MOCK_DATA, { language: "ja" });
     expect(html).toContain('lang="ja"');
     expect(html).toContain("サマリー");
     expect(html).toContain("ハイライト");
@@ -170,7 +157,7 @@ describe("renderReport", () => {
   });
 
   it("renders Simplified Chinese locale", () => {
-    const html = renderReport(MOCK_WITH_AI, { language: "zh-CN" });
+    const html = renderReport(MOCK_DATA, { language: "zh-CN" });
     expect(html).toContain('lang="zh-CN"');
     expect(html).toContain("摘要");
     expect(html).toContain("Noto Sans SC");

--- a/src/renderer/templates/partials/header.hbs
+++ b/src/renderer/templates/partials/header.hbs
@@ -4,6 +4,6 @@
     <span>{{username}}</span>
   </a>
   <div class="header-week">{{weekLabel dateRange.from dateRange.to}}</div>
-  <h1 class="header-title">{{#if aiContent}}{{aiContent.title}}{{else}}{{userWeek username}}{{/if}}</h1>
-  {{#if aiContent}}<p class="header-sub">{{aiContent.subtitle}}</p>{{/if}}
+  <h1 class="header-title">{{aiContent.title}}</h1>
+  <p class="header-sub">{{aiContent.subtitle}}</p>
 </div>

--- a/src/renderer/templates/report.hbs
+++ b/src/renderer/templates/report.hbs
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="{{lang}}">
 <head>
-  <title>{{#if aiContent}}{{aiContent.title}}{{else}}{{userWeek username}}{{/if}} - {{dateRange.from}} - {{dateRange.to}}</title>
+  <title>{{aiContent.title}} - {{dateRange.from}} - {{dateRange.to}}</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="{{#if aiContent}}{{aiContent.subtitle}}{{else}}{{i18n.weeklyReport}} for {{username}}{{/if}}" />
-  <meta property="og:title" content="{{#if aiContent}}{{aiContent.title}}{{else}}{{userWeek username}}{{/if}}" />
-  <meta property="og:description" content="{{#if aiContent}}{{aiContent.subtitle}}{{else}}{{i18n.weeklyReport}}{{/if}}" />
+  <meta name="description" content="{{aiContent.subtitle}}" />
+  <meta property="og:title" content="{{aiContent.title}}" />
+  <meta property="og:description" content="{{aiContent.subtitle}}" />
   <meta property="og:image" content="{{avatarUrl}}" />
   <meta property="og:type" content="website" />
   <meta name="view-transition" content="same-origin" />
@@ -24,11 +24,9 @@
 
 <div class="page">
   {{> header}}
-  {{#if aiContent}}
   {{> overview}}
   {{> summaries}}
   {{> highlights}}
-  {{/if}}
 </div>
 
 {{> footer}}

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,7 @@ export type WeeklyReportData = {
   issues: Issue[];
   events: GitHubEvent[];
   externalContributions: ExternalContribution[];
-  aiContent: AIContent | null;
+  aiContent: AIContent;
 };
 
 // LLM structured output


### PR DESCRIPTION
## Summary

- Make `aiContent` required (no longer nullable) in `WeeklyReportData`
- `render` command fails with clear error if `llm-data.yaml` is missing
- Remove all `{{#if aiContent}}` template guards
- `action.yml` generate step fails instead of silently skipping

## Motivation

Without LLM content, the report is just a header and footer. LLM is effectively required for a useful report. This makes that explicit rather than producing empty pages.

## Changes

| File | Change |
|---|---|
| `types.ts` | `aiContent: AIContent \| null` → `aiContent: AIContent` |
| `render.ts` | Error + exit if `llm-data.yaml` missing |
| `report.hbs` | Remove `{{#if aiContent}}` guard, simplify meta tags |
| `header.hbs` | Remove fallback title/subtitle |
| `fetch.ts` | Remove `aiContent: null` from intermediate object |
| `action.yml` | Generate step always runs (no skip condition) |
| `renderer.test.ts` | Remove null test, unify mock data |

Closes #21