### PR TITLE
feat: add share buttons for X, LinkedIn, and Bluesky

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -14,6 +14,7 @@ export type LocaleStrings = {
   allWeeks: string;
   prevWeek: string;
   nextWeek: string;
+  share: string;
   poweredBy: string;
   weeklyReports: string;
   weeklyReport: string;
@@ -53,6 +54,7 @@ const en: Locale = {
   allWeeks: "All weeks",
   prevWeek: "Previous week",
   nextWeek: "Next week",
+  share: "Share",
   poweredBy: "Powered by",
   weeklyReports: "Weekly Reports",
   weeklyReport: "Weekly Report",
@@ -68,6 +70,7 @@ const ja: Locale = {
   allWeeks: "すべての週",
   prevWeek: "前の週",
   nextWeek: "次の週",
+  share: "シェア",
   poweredBy: "Powered by",
   weeklyReports: "ウィークリーレポート",
   weeklyReport: "ウィークリーレポート",
@@ -83,6 +86,7 @@ const zhCN: Locale = {
   allWeeks: "所有周报",
   prevWeek: "上一周",
   nextWeek: "下一周",
+  share: "分享",
   poweredBy: "Powered by",
   weeklyReports: "每周报告",
   weeklyReport: "每周报告",
@@ -98,6 +102,7 @@ const zhTW: Locale = {
   allWeeks: "所有週報",
   prevWeek: "上一週",
   nextWeek: "下一週",
+  share: "分享",
   poweredBy: "Powered by",
   weeklyReports: "每週報告",
   weeklyReport: "每週報告",
@@ -113,6 +118,7 @@ const ko: Locale = {
   allWeeks: "모든 주",
   prevWeek: "이전 주",
   nextWeek: "다음 주",
+  share: "공유",
   poweredBy: "Powered by",
   weeklyReports: "주간 보고서",
   weeklyReport: "주간 보고서",
@@ -128,6 +134,7 @@ const es: Locale = {
   allWeeks: "Todas las semanas",
   prevWeek: "Semana anterior",
   nextWeek: "Semana siguiente",
+  share: "Compartir",
   poweredBy: "Powered by",
   weeklyReports: "Informes semanales",
   weeklyReport: "Informe semanal",
@@ -143,6 +150,7 @@ const fr: Locale = {
   allWeeks: "Toutes les semaines",
   prevWeek: "Semaine precedente",
   nextWeek: "Semaine suivante",
+  share: "Partager",
   poweredBy: "Powered by",
   weeklyReports: "Rapports hebdomadaires",
   weeklyReport: "Rapport hebdomadaire",
@@ -158,6 +166,7 @@ const de: Locale = {
   allWeeks: "Alle Wochen",
   prevWeek: "Vorherige Woche",
   nextWeek: "Naechste Woche",
+  share: "Teilen",
   poweredBy: "Powered by",
   weeklyReports: "Wochenberichte",
   weeklyReport: "Wochenbericht",
@@ -173,6 +182,7 @@ const pt: Locale = {
   allWeeks: "Todas as semanas",
   prevWeek: "Semana anterior",
   nextWeek: "Proxima semana",
+  share: "Compartilhar",
   poweredBy: "Powered by",
   weeklyReports: "Relatorios semanais",
   weeklyReport: "Relatorio semanal",
@@ -188,6 +198,7 @@ const ru: Locale = {
   allWeeks: "Все недели",
   prevWeek: "Предыдущая неделя",
   nextWeek: "Следующая неделя",
+  share: "Поделиться",
   poweredBy: "Powered by",
   weeklyReports: "Еженедельные отчеты",
   weeklyReport: "Еженедельный отчет",

--- a/src/renderer/templates/report.hbs
+++ b/src/renderer/templates/report.hbs
@@ -76,6 +76,15 @@
 </article>
 </main>
 
+{{#if canonicalUrl}}
+<div class="share-bar">
+  <span class="share-label">{{i18n.share}}</span>
+  <a href="https://x.com/intent/tweet?url={{{canonicalUrl}}}&text={{aiContent.title}}" target="_blank" rel="noopener nofollow" class="share-btn share-x" aria-label="Share on X">𝕏</a>
+  <a href="https://www.linkedin.com/sharing/share-offsite/?url={{{canonicalUrl}}}" target="_blank" rel="noopener nofollow" class="share-btn share-linkedin" aria-label="Share on LinkedIn">in</a>
+  <a href="https://bsky.app/intent/compose?text={{aiContent.title}}%20{{{canonicalUrl}}}" target="_blank" rel="noopener nofollow" class="share-btn share-bsky" aria-label="Share on Bluesky">🦋</a>
+</div>
+{{/if}}
+
 {{#if prevWeek}}{{#if nextWeek}}
 <nav class="week-nav" aria-label="Week navigation">
   <a href="{{prevWeek}}" class="week-nav-link">&larr; {{i18n.prevWeek}}</a>

--- a/src/renderer/themes.ts
+++ b/src/renderer/themes.ts
@@ -449,6 +449,42 @@ export const buildCSS = (theme: Theme, language: Language = "en"): string => {
       font-size: 0.75rem;
     }
 
+    /* SHARE BAR */
+    .share-bar {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 2rem 0;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .share-label {
+      font-family: ${f.monoFamily};
+      font-size: 0.6875rem;
+      color: ${c.textTertiary};
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+    .share-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px; height: 32px;
+      border-radius: 6px;
+      border: 1px solid ${c.chipBorder};
+      background: ${c.chipBg};
+      color: ${c.textSecondary};
+      text-decoration: none;
+      font-size: 0.75rem;
+      font-weight: 600;
+      transition: all 0.2s;
+    }
+    .share-btn:hover {
+      border-color: ${c.accent};
+      color: ${c.text};
+      box-shadow: 0 0 8px ${c.accent}33;
+    }
+
     /* WEEK NAV (prev/next) */
     .week-nav {
       max-width: 720px;


### PR DESCRIPTION
## Summary

- Add CSS-only share bar with X, LinkedIn, and Bluesky share buttons
- Uses intent URLs (no JavaScript required)
- Only displayed when `--base-url` is set (canonical URL available)
- i18n "Share" label for all 10 languages

## Share bar

Placed between article content and week navigation. Styled to match existing chip/button design with hover effects.

- **X**: `https://x.com/intent/tweet?url=...&text=...`
- **LinkedIn**: `https://www.linkedin.com/sharing/share-offsite/?url=...`
- **Bluesky**: `https://bsky.app/intent/compose?text=...`

Closes #44