### PR TITLE
fix: increase max_tokens from 4096 to 16384 for all LLM providers

### DIFF
--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -10,7 +10,7 @@ export const createAnthropicProvider = (config: LLMConfig): LLMProvider => {
     generate: async (prompt: string): Promise<string> => {
       const response = await client.messages.create({
         model: config.model,
-        max_tokens: 4096,
+        max_tokens: 16384,
         messages: [{ role: "user", content: prompt }],
       });
       const block = response.content[0];

--- a/src/llm/providers/grok.ts
+++ b/src/llm/providers/grok.ts
@@ -13,7 +13,7 @@ export const createGrokProvider = (config: LLMConfig): LLMProvider => {
       const response = await client.chat.completions.create({
         model: config.model,
         messages: [{ role: "user", content: prompt }],
-        max_tokens: 4096,
+        max_tokens: 16384,
         temperature: 0.7,
       });
       return response.choices[0]?.message?.content?.trim() ?? "";

--- a/src/llm/providers/groq.ts
+++ b/src/llm/providers/groq.ts
@@ -13,7 +13,7 @@ export const createGroqProvider = (config: LLMConfig): LLMProvider => {
       const response = await client.chat.completions.create({
         model: config.model,
         messages: [{ role: "user", content: prompt }],
-        max_tokens: 4096,
+        max_tokens: 16384,
         temperature: 0.7,
       });
       return response.choices[0]?.message?.content?.trim() ?? "";

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -11,7 +11,7 @@ export const createOpenAIProvider = (config: LLMConfig): LLMProvider => {
       const response = await client.chat.completions.create({
         model: config.model,
         messages: [{ role: "user", content: prompt }],
-        max_tokens: 4096,
+        max_tokens: 16384,
         temperature: 0.7,
       });
       return response.choices[0]?.message?.content?.trim() ?? "";

--- a/src/llm/providers/openrouter.ts
+++ b/src/llm/providers/openrouter.ts
@@ -13,7 +13,7 @@ export const createOpenRouterProvider = (config: LLMConfig): LLMProvider => {
       const response = await client.chat.completions.create({
         model: config.model,
         messages: [{ role: "user", content: prompt }],
-        max_tokens: 4096,
+        max_tokens: 16384,
         temperature: 0.7,
       });
       return response.choices[0]?.message?.content?.trim() ?? "";


### PR DESCRIPTION
## Summary

- Increase `max_tokens` from 4096 to 16384 across all 5 LLM providers (openai, anthropic, gemini, groq, grok, openrouter)
- 4096 was too low for rich structured YAML output, causing truncated reports