### PR TITLE
feat: add date input to generated workflow files

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -314,11 +314,6 @@ on:
   schedule:
     - cron: '${cron}'  # midnight ${opts.timezone}
   workflow_dispatch:
-    inputs:
-      date:
-        description: 'Target date (YYYY-MM-DD, default: today)'
-        required: false
-        type: string
 
 permissions:
   contents: write
@@ -336,7 +331,6 @@ jobs:
           mode: 'daily'
           language: '${opts.language}'
           timezone: '${opts.timezone}'
-          date: \${{ inputs.date }}
 `;
 };
 


### PR DESCRIPTION
## Summary

- Add optional `date` input (YYYY-MM-DD) to both `daily-fetch.yml` and `weekly-report.yml` generated by the setup command
- Passed through to the action's `date` parameter
- Useful for backfilling past weeks or re-running specific dates from the Actions UI