### PR TITLE
refactor: deploy to main branch output/ instead of gh-pages

### DIFF
--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -156,10 +156,8 @@ Add your LLM provider's API key as a secret:
 
 1. Go to **Settings > Pages**
 2. Under **Source**, select **Deploy from a branch**
-3. Select the `gh-pages` branch and `/ (root)` folder
+3. Select the `main` branch and `/output` folder
 4. Click **Save**
-
-If the `gh-pages` branch doesn't exist yet, it will be created automatically on the first weekly report deployment.
 
 ## Step 5: Run the Workflow
 
@@ -214,7 +212,7 @@ https://YOUR_USERNAME.github.io/REPO_NAME
 
 If you use a custom domain:
 
-1. Add a `CNAME` file to your `gh-pages` branch with your domain
+1. Add a `CNAME` file to your `output/` directory with your domain
 2. Configure the custom domain in **Settings > Pages > Custom domain**
 3. Add `BASE_URL` to your workflow env:
 
@@ -264,5 +262,5 @@ LLM errors will cause the workflow to fail. Check:
 ### GitHub Pages not showing
 
 - Make sure Pages is enabled in Settings > Pages
-- Check that the `gh-pages` branch exists
+- Check that the `output/` directory exists on the `main` branch
 - Wait a few minutes for the first deployment to propagate

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -40,7 +40,7 @@ const buildRepoUrl = (repo: string | undefined): string => {
 const run = async (options: DeployCommandOptions): Promise<void> => {
   const weekId = getWeekId(options.date, options.timezone);
 
-  console.log(`Deploying ${options.directory} to gh-pages...`);
+  console.log(`Deploying ${options.directory}...`);
   await deploy({
     repoUrl: options.repoUrl,
     directory: options.directory,
@@ -52,7 +52,7 @@ const run = async (options: DeployCommandOptions): Promise<void> => {
 export const registerDeploy = (program: Command): void => {
   program
     .command("deploy")
-    .description("Deploy generated report to GitHub Pages (gh-pages branch)")
+    .description("Deploy generated report to GitHub Pages")
     .option("-d, --directory <dir>", "Directory containing generated HTML files (env: OUTPUT_DIR, default: ./output)")
     .option("-r, --repo <slug>", "Repository (owner/repo or full URL, env: GITHUB_REPOSITORY)")
     .option("--timezone <tz>", "IANA timezone (env: TIMEZONE, default: UTC)")

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -692,28 +692,9 @@ const enablePages = async (
   token: string,
   repo: string,
 ): Promise<string> => {
-  // Ensure gh-pages branch exists
-  const mainRef = await ghGet(token, `/repos/${repo}/git/ref/heads/main`);
-  if (!mainRef.ok) throw new Error("Cannot find main branch");
-  const { object } = (await mainRef.json()) as { object: { sha: string } };
-
-  const ghPagesRef = await ghGet(
-    token,
-    `/repos/${repo}/git/ref/heads/gh-pages`,
-  );
-  if (!ghPagesRef.ok) {
-    const createRef = await ghPost(token, `/repos/${repo}/git/refs`, {
-      ref: "refs/heads/gh-pages",
-      sha: object.sha,
-    });
-    if (!createRef.ok) {
-      throw new Error("Failed to create gh-pages branch");
-    }
-  }
-
-  // Enable Pages (may already be enabled)
+  // Enable Pages from main branch, /output directory (may already be enabled)
   await ghPost(token, `/repos/${repo}/pages`, {
-    source: { branch: "gh-pages", path: "/" },
+    source: { branch: "main", path: "/output" },
   });
 
   const [owner, name] = repo.split("/");

--- a/src/deployer/index.ts
+++ b/src/deployer/index.ts
@@ -1,11 +1,11 @@
-// Deploy a directory to gh-pages branch
+// Deploy output directory by committing to the current branch and pushing
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 const exec = promisify(execFile);
 
-const git = (args: string[], cwd: string) =>
+const git = (args: string[], cwd?: string) =>
   exec("git", args, { cwd });
 
 export type DeployOptions = {
@@ -15,13 +15,17 @@ export type DeployOptions = {
 };
 
 export const deploy = async (options: DeployOptions): Promise<void> => {
-  const { repoUrl, directory, message = "deploy" } = options;
+  const { directory, message = "deploy" } = options;
 
-  await git(["init"], directory);
-  await git(["checkout", "--orphan", "gh-pages"], directory);
-  await git(["add", "."], directory);
-  await git(["config", "user.name", "github-weekly-reporter"], directory);
-  await git(["config", "user.email", "github-weekly-reporter@users.noreply.github.com"], directory);
-  await git(["commit", "-m", message], directory);
-  await git(["push", repoUrl, "gh-pages", "--force"], directory);
+  // Stage output files and commit to current branch
+  await git(["add", "-f", directory]);
+
+  const { stdout } = await git(["status", "--porcelain"]);
+  if (!stdout.trim()) {
+    console.log("No changes to deploy.");
+    return;
+  }
+
+  await git(["commit", "-m", message]);
+  await git(["push"]);
 };


### PR DESCRIPTION
## Summary

- Deploy now commits `output/` to the current branch (main) instead of force-pushing an orphan `gh-pages` branch
- Past reports are preserved across deployments
- GitHub Pages source is set to `main` branch `/output` directory
- Removed gh-pages branch creation from setup

## Problem

The deployer was creating an orphan `gh-pages` branch with `--force` push on every deploy, wiping all previous reports. Only the latest week's report survived.

## Solution

Deploy simply does `git add -f output/ && git commit && git push` to the current branch. Pages reads from `main:/output`.