### PR TITLE
fix: revert to gh-pages deploy but preserve existing files

### DIFF
--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -156,7 +156,9 @@ Add your LLM provider's API key as a secret:
 
 1. Go to **Settings > Pages**
 2. Under **Source**, select **Deploy from a branch**
-3. Select the `main` branch and `/output` folder
+3. Select the `gh-pages` branch and `/ (root)` folder
+
+The `gh-pages` branch is created automatically on the first deploy.
 4. Click **Save**
 
 ## Step 5: Run the Workflow
@@ -212,7 +214,7 @@ https://YOUR_USERNAME.github.io/REPO_NAME
 
 If you use a custom domain:
 
-1. Add a `CNAME` file to your `output/` directory with your domain
+1. Add a `CNAME` file (the render command generates it automatically for custom domains)
 2. Configure the custom domain in **Settings > Pages > Custom domain**
 3. Add `BASE_URL` to your workflow env:
 
@@ -262,5 +264,5 @@ LLM errors will cause the workflow to fail. Check:
 ### GitHub Pages not showing
 
 - Make sure Pages is enabled in Settings > Pages
-- Check that the `output/` directory exists on the `main` branch
+- Check that the `gh-pages` branch exists (created on first deploy)
 - Wait a few minutes for the first deployment to propagate

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -52,7 +52,7 @@ const run = async (options: DeployCommandOptions): Promise<void> => {
 export const registerDeploy = (program: Command): void => {
   program
     .command("deploy")
-    .description("Deploy generated report to GitHub Pages")
+    .description("Deploy generated report to GitHub Pages (gh-pages branch)")
     .option("-d, --directory <dir>", "Directory containing generated HTML files (env: OUTPUT_DIR, default: ./output)")
     .option("-r, --repo <slug>", "Repository (owner/repo or full URL, env: GITHUB_REPOSITORY)")
     .option("--timezone <tz>", "IANA timezone (env: TIMEZONE, default: UTC)")

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -694,7 +694,7 @@ const enablePages = async (
 ): Promise<string> => {
   // Enable Pages from main branch, /output directory (may already be enabled)
   await ghPost(token, `/repos/${repo}/pages`, {
-    source: { branch: "main", path: "/output" },
+    source: { branch: "gh-pages", path: "/" },
   });
 
   const [owner, name] = repo.split("/");

--- a/src/deployer/index.ts
+++ b/src/deployer/index.ts
@@ -1,11 +1,14 @@
-// Deploy output directory by committing to the current branch and pushing
+// Deploy output directory to gh-pages branch, preserving existing files
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { cp, mkdtemp, rm, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 const exec = promisify(execFile);
 
-const git = (args: string[], cwd?: string) =>
+const git = (args: string[], cwd: string) =>
   exec("git", args, { cwd });
 
 export type DeployOptions = {
@@ -15,17 +18,42 @@ export type DeployOptions = {
 };
 
 export const deploy = async (options: DeployOptions): Promise<void> => {
-  const { directory, message = "deploy" } = options;
+  const { repoUrl, directory, message = "deploy" } = options;
+  const tmp = await mkdtemp(join(tmpdir(), "gwr-deploy-"));
 
-  // Stage output files and commit to current branch
-  await git(["add", "-f", directory]);
+  try {
+    // Try to clone existing gh-pages branch
+    try {
+      await exec("git", ["clone", "--branch", "gh-pages", "--single-branch", "--depth", "1", repoUrl, tmp]);
+    } catch {
+      // gh-pages doesn't exist yet, init a fresh repo
+      await git(["init"], tmp);
+      await git(["checkout", "--orphan", "gh-pages"], tmp);
+    }
 
-  const { stdout } = await git(["status", "--porcelain"]);
-  if (!stdout.trim()) {
-    console.log("No changes to deploy.");
-    return;
+    await git(["config", "user.name", "github-weekly-reporter[bot]"], tmp);
+    await git(["config", "user.email", "github-weekly-reporter[bot]@users.noreply.github.com"], tmp);
+
+    // Copy output files into the cloned gh-pages directory
+    const entries = await readdir(directory);
+    await Promise.all(
+      entries.map((entry) =>
+        cp(join(directory, entry), join(tmp, entry), { recursive: true, force: true }),
+      ),
+    );
+
+    // Stage all changes
+    await git(["add", "."], tmp);
+
+    const { stdout } = await git(["status", "--porcelain"], tmp);
+    if (!stdout.trim()) {
+      console.log("No changes to deploy.");
+      return;
+    }
+
+    await git(["commit", "-m", message], tmp);
+    await git(["push", repoUrl, "gh-pages", "--force"], tmp);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
   }
-
-  await git(["commit", "-m", message]);
-  await git(["push"]);
 };


### PR DESCRIPTION
## Summary

- Revert to gh-pages deployment (GitHub Pages only supports `/` or `/docs` from main)
- Deployer now clones existing gh-pages branch first, copies new output files on top, then commits and pushes
- Past reports are preserved across deployments (no more orphan + force push)
- If gh-pages doesn't exist yet, creates it fresh

## Previous behavior

Orphan branch + force push = all past reports wiped every deploy.

## New behavior

Clone gh-pages -> copy output/ -> commit -> push. Existing files stay.