### PR TITLE
docs: improve README and add documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,42 +10,34 @@
 
 Every week, this tool looks at everything you did on GitHub (commits, pull requests, code reviews) and generates a polished, shareable report page with AI-written summaries. It runs as a GitHub Action, deploys to GitHub Pages, and costs nothing.
 
-One command to set up. Zero maintenance after that.
-
-```bash
-npx github-weekly-reporter setup
-```
-
 [See a live example](https://unhappychoice.github.io/weekly-report/)
 
-## Prerequisites
+## What You Need
 
-Before running setup, have these ready:
+Have these two things ready before running setup:
 
 1. **GitHub fine-grained PAT** with `All repositories` access and these permissions (all Read & Write):
    `Administration`, `Contents`, `Actions`, `Secrets`, `Pages`, `Workflows`
    ([Create one](https://github.com/settings/personal-access-tokens/new))
 
-2. **LLM API key** from one of the supported providers.
+2. **LLM API key** from any supported provider:
+
    | Provider | Free Tier | Get API Key |
    |---|---|---|
-   | OpenRouter | Yes | https://openrouter.ai/settings/keys |
-   | Groq | Yes | https://console.groq.com/keys |
-   | Google Gemini | Yes | https://aistudio.google.com/apikey |
+   | **OpenRouter** | Yes (25+ free models) | https://openrouter.ai/settings/keys |
+   | **Groq** | Yes (generous limits) | https://console.groq.com/keys |
+   | **Google Gemini** | Yes | https://aistudio.google.com/apikey |
    | OpenAI | No | https://platform.openai.com/api-keys |
    | Anthropic | No | https://console.anthropic.com/settings/keys |
    | Grok (xAI) | No | https://console.x.ai |
 
-3. **LLM model name** for your chosen provider:
-
-   | Provider | Models |
-   |---|---|
-   | OpenRouter | https://openrouter.ai/models |
-   | Groq | https://console.groq.com/docs/models |
-   | Google Gemini | https://ai.google.dev/gemini-api/docs/models |
-   | OpenAI | https://platform.openai.com/docs/models |
-   | Anthropic | https://docs.anthropic.com/en/docs/about-claude/models |
-   | Grok (xAI) | https://docs.x.ai/docs/models |
+   You also need a **model name**. Find available models on your provider's page:
+   [OpenRouter](https://openrouter.ai/models),
+   [Groq](https://console.groq.com/docs/models),
+   [Gemini](https://ai.google.dev/gemini-api/docs/models),
+   [OpenAI](https://platform.openai.com/docs/models),
+   [Anthropic](https://docs.anthropic.com/en/docs/about-claude/models),
+   [Grok](https://docs.x.ai/docs/models)
 
 ## Quick Start
 
@@ -53,61 +45,45 @@ Before running setup, have these ready:
 npx github-weekly-reporter setup
 ```
 
-The setup command will walk you through everything:
-- Creates a repository
-- Adds workflow files (daily fetch + weekly report)
-- Configures secrets (PAT and LLM API key)
-- Enables GitHub Pages
-- Triggers your first weekly report
+The setup command walks you through everything interactively:
+
+1. Creates a repository for your reports
+2. Adds workflow files (daily fetch + weekly report)
+3. Stores secrets (PAT and LLM API key)
+4. Enables GitHub Pages
+5. Triggers your first report
+
+Your first report will be live within 5 minutes.
 
 See [Manual Setup](docs/manual-setup.md) if you prefer to configure everything yourself.
 
+## Cost
+
+**The entire stack runs at $0/month on a public repository.**
+
+| Component | Cost | Details |
+|---|---|---|
+| GitHub Actions | Free | ~80 min/month (30 daily runs + 4 weekly runs). Public repos have unlimited free minutes. |
+| LLM | Free | One API call per week. OpenRouter, Groq, and Gemini all offer free tiers. |
+| GitHub Pages | Free | Hosting and deployment included for public repos. |
+| npm package | Free | Runs via `npx`, no installation required. |
+
+On paid LLM providers (OpenAI, Anthropic, Grok), the cost is roughly $0.10-0.35/month (one call per week, ~4-8K tokens each).
+
+Private repositories work too. GitHub Free gives 2,000 Actions minutes/month (this tool uses ~4% of that), but GitHub Pages on private repos requires a paid GitHub plan.
+
 ## Features
 
-- Weekly stats: commits, PRs opened/merged, issues, reviews
+- Weekly stats: commits, PRs opened/merged, reviews
 - Top repositories by activity
 - Language breakdown (CSS-only chart)
 - 7-day contribution heatmap
-- AI-generated narrative summary (6 providers, free tiers available)
+- AI-generated narrative summary
 - Dark theme with responsive design
-- Self-contained HTML (no external requests, no JavaScript required)
+- Self-contained HTML, no JavaScript
 - SEO optimized (OG images, JSON-LD, sitemap)
 - Deploys to GitHub Pages with weekly archive
-- Internationalization (10 languages)
-
-## LLM Providers
-
-AI narratives are required for report generation. Six providers are supported, including free tiers:
-
-| Provider | Free Tier | Env Variable |
-|---|---|---|
-| **OpenRouter** | Yes (25+ free models) | `OPENROUTER_API_KEY` |
-| **Groq** | Yes (generous) | `GROQ_API_KEY` |
-| **Google Gemini** | Yes | `GEMINI_API_KEY` |
-| OpenAI | No | `OPENAI_API_KEY` |
-| Anthropic | No | `ANTHROPIC_API_KEY` |
-| Grok (xAI) | No | `GROK_API_KEY` |
-
-OpenRouter and Groq are recommended for free usage. Both offer high-quality models at no cost. For model selection, see each provider's documentation:
-
-- OpenRouter: https://openrouter.ai/models
-- Groq: https://console.groq.com/docs/models
-- Gemini: https://ai.google.dev/gemini-api/docs/models
-- OpenAI: https://platform.openai.com/docs/models
-- Anthropic: https://docs.anthropic.com/en/docs/about-claude/models
-- Grok: https://docs.x.ai/docs/models
-
-If the LLM call fails, the workflow will stop with an error. Make sure your API key and model name are correct.
-
-## Generating a Report Manually
-
-After setup, daily fetches run automatically. To generate a weekly report anytime:
-
-1. Go to your repository's **Actions** tab
-2. Click **Weekly Report**
-3. Click **Run workflow**
-
-The report will be built and deployed to GitHub Pages within a few minutes.
+- 10 languages supported
 
 ## Supported Languages
 
@@ -126,18 +102,12 @@ The report will be built and deployed to GitHub Pages within a few minutes.
 
 ## Documentation
 
-- [Manual Setup](docs/manual-setup.md) - step-by-step guide without the setup command
-- [CLI Reference](docs/cli-reference.md) - all commands and environment variables
-
-## URL Structure
-
-Reports are archived by ISO week:
-
-```
-https://<user>.github.io/<repo>/           # Index page (links to all reports)
-https://<user>.github.io/<repo>/2026/W14/  # Weekly report
-https://<user>.github.io/<repo>/2026/W13/  # Previous week
-```
+- [How It Works](docs/how-it-works.md): the pipeline, data flow, and what gets collected
+- [Manual Setup](docs/manual-setup.md): step-by-step guide without the setup command
+- [Customization](docs/customization.md): change language, timezone, LLM provider, custom domain, and more
+- [CLI Reference](docs/cli-reference.md): all commands and environment variables
+- [FAQ](docs/faq.md): common questions about cost, privacy, and limitations
+- [Troubleshooting](docs/troubleshooting.md): fixing workflow failures, missing data, and setup errors
 
 ## License
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,0 +1,146 @@
+# Customization
+
+After running `setup`, all configuration lives in two workflow files in your repository:
+
+- `.github/workflows/daily-fetch.yml`: schedule and data collection
+- `.github/workflows/weekly-report.yml`: report generation, rendering, and deployment
+
+Edit these files directly to change settings. There is no re-run setup command; just edit the YAML.
+
+## Site Title
+
+The title appears in the header, hero section, index page, and OG images.
+
+Edit `weekly-report.yml`:
+
+```yaml
+env:
+  SITE_TITLE: 'My Weekly Report'
+```
+
+The default is `Dev\nPulse`. Use `\n` for a line break in the hero section.
+
+## Language
+
+Controls UI text, date formatting, font, and the language the AI writes in.
+
+Edit **both** workflow files, in the `with:` block:
+
+```yaml
+with:
+  language: 'ja'
+```
+
+Supported values: `en`, `ja`, `zh-CN`, `zh-TW`, `ko`, `es`, `fr`, `de`, `pt`, `ru`.
+
+Both files should use the same language for consistency.
+
+## Timezone
+
+Controls when the cron schedule runs and how dates are formatted.
+
+Two things must be updated:
+
+1. The `timezone` input in **both** workflow files:
+
+   ```yaml
+   with:
+     timezone: 'Asia/Tokyo'
+   ```
+
+2. The `cron:` schedule in **both** workflow files. The cron runs in UTC, so convert your local midnight:
+
+   | Timezone | Daily Cron (midnight local) |
+   |---|---|
+   | UTC | `0 0 * * *` |
+   | America/New_York (UTC-5) | `0 5 * * *` |
+   | America/Los_Angeles (UTC-8) | `0 8 * * *` |
+   | Europe/Berlin (UTC+1/+2) | `0 23 * * *` or `0 22 * * *` |
+   | Asia/Tokyo (UTC+9) | `0 15 * * *` |
+   | Asia/Shanghai (UTC+8) | `0 16 * * *` |
+
+   The weekly cron should be 1 hour after the daily cron, on Mondays only. For example, if the daily cron is `0 15 * * *`, the weekly cron is `0 16 * * 1`.
+
+## LLM Provider and Model
+
+To switch providers, update three things in `weekly-report.yml`:
+
+1. The `llm-provider` value
+2. The `llm-model` value
+3. The API key input name and corresponding secret
+
+```yaml
+with:
+  llm-provider: 'groq'
+  llm-model: 'llama-3.3-70b-versatile'
+  groq-api-key: ${{ secrets.GROQ_API_KEY }}
+```
+
+Then add the new API key as a repository secret: **Settings > Secrets and variables > Actions > New repository secret**.
+
+API key input names per provider:
+
+| Provider | Input Name | Secret Name |
+|---|---|---|
+| OpenRouter | `openrouter-api-key` | `OPENROUTER_API_KEY` |
+| Groq | `groq-api-key` | `GROQ_API_KEY` |
+| Google Gemini | `gemini-api-key` | `GEMINI_API_KEY` |
+| OpenAI | `openai-api-key` | `OPENAI_API_KEY` |
+| Anthropic | `anthropic-api-key` | `ANTHROPIC_API_KEY` |
+| Grok (xAI) | `grok-api-key` | `GROK_API_KEY` |
+
+To change only the model (same provider), just update `llm-model`. No secret changes needed.
+
+## Custom Domain
+
+By default, reports are hosted at `https://<user>.github.io/<repo>/`.
+
+To use a custom domain:
+
+1. Add `BASE_URL` to the `env:` block in `weekly-report.yml`:
+
+   ```yaml
+   env:
+     SITE_TITLE: 'My Reports'
+     BASE_URL: 'https://reports.example.com'
+   ```
+
+2. Configure the domain in your repository: **Settings > Pages > Custom domain**.
+
+3. Set up DNS records pointing to GitHub Pages ([GitHub docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site)).
+
+The render step automatically generates a `CNAME` file when the base URL is not a `.github.io` domain.
+
+## Schedule
+
+Both workflows use `workflow_dispatch`, so you can always trigger them manually from the **Actions** tab.
+
+To change the automatic schedule, edit the `cron:` line. GitHub Actions cron uses UTC and follows standard cron syntax:
+
+```
+# ┌───── minute (0-59)
+# │ ┌───── hour (0-23)
+# │ │ ┌───── day of month (1-31)
+# │ │ │ ┌───── month (1-12)
+# │ │ │ │ ┌───── day of week (0-6, 0=Sunday)
+# │ │ │ │ │
+# * * * * *
+```
+
+The daily fetch should run every day. The weekly report should run once a week (typically Monday), after the daily fetch completes.
+
+## Pinning the CLI Version
+
+By default, workflows use the latest version of the npm package. To pin a specific version for reproducibility, add the `version` input:
+
+```yaml
+with:
+  version: '0.3.0'
+```
+
+## What Cannot Be Customized
+
+- **Theme**: the dark theme is built-in and not configurable.
+- **Deploy branch**: always deploys to `gh-pages`.
+- **Report structure**: the HTML layout and sections are fixed.
+- **LLM parameters**: `max_tokens` (16384) and `temperature` (0.7) are not configurable.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,106 @@
+# FAQ
+
+## Cost and Plans
+
+### Is this completely free?
+
+Yes. On a public repository, every component is free:
+
+- **GitHub Actions**: public repos have unlimited free minutes. This tool uses roughly 80 minutes/month (daily fetch runs ~2 min/day, weekly report runs ~5 min/week).
+- **LLM**: OpenRouter, Groq, and Google Gemini all offer free tiers. The tool makes one LLM call per week.
+- **GitHub Pages**: free hosting for public repos.
+
+### Does it work on a private repository?
+
+Yes, but with caveats:
+
+- GitHub Free gives 2,000 Actions minutes/month for private repos. This tool uses about 80, so that is fine.
+- GitHub Pages on private repos requires a paid GitHub plan (Pro, Team, or Enterprise).
+
+### How much does a paid LLM cost?
+
+Roughly **$0.10-0.35/month**. Each report is a single LLM call with about 4-8K tokens. At OpenAI or Anthropic pricing, that is a few cents per report, four reports per month.
+
+### Which LLM provider should I pick?
+
+**OpenRouter** is the default recommendation. It offers 25+ free models with no credit card required. **Groq** is the second choice for its generous free tier and fast inference.
+
+## Privacy
+
+### Does the report include private repository activity?
+
+No. The tool only collects public events from the GitHub Events API. Commits, PRs, and reviews from private repositories are not included, regardless of your token permissions.
+
+### What data is sent to the LLM provider?
+
+A summary of your public GitHub activity for the week: commit counts, PR titles and descriptions, review activity, and repository names. This is sent as a single prompt to generate the narrative.
+
+No telemetry, analytics, or tracking is included in the tool or the generated reports.
+
+### Are the reports public?
+
+Yes, by default. The setup command creates a public repository and deploys to GitHub Pages. The generated HTML includes `robots.txt` with `Allow: /` and a `sitemap.xml` for search engines.
+
+If you want private reports, you can run the CLI locally without the `deploy` step to generate HTML files on your machine.
+
+## How It Works
+
+### What is the daily fetch for?
+
+The daily fetch collects your GitHub activity events and saves them locally. GitHub's Events API only retains the most recent 300 events per user, so fetching daily ensures nothing is lost for active users.
+
+Running daily-fetch multiple times in a day is safe. Events are deduplicated by ID.
+
+### What does the weekly report do?
+
+The weekly report runs four steps in sequence:
+
+1. **weekly-fetch**: collects the full week's data (accumulated events + PR search + contribution stats)
+2. **generate**: sends the data to an LLM and gets back a narrative summary
+3. **render**: produces the HTML report, OG images, sitemap, and index page
+4. **deploy**: pushes everything to the `gh-pages` branch
+
+### Which week does the report cover?
+
+Always the **previous** ISO week (Monday to Sunday). If you run the workflow on Monday, it covers the week that just ended. This is by design: the tool waits for the week to finish before summarizing it.
+
+Use the `--date` flag (or the `date` workflow input) to target a specific week. The date can be any day within the target week.
+
+### Can I regenerate a past report?
+
+Yes. Trigger the Weekly Report workflow manually and set the `date` input to any date within the target week (format: `YYYY-MM-DD`). The daily event data must still be in the `data/` directory.
+
+## Limitations
+
+### Some PRs or events are missing
+
+The GitHub Events API has a hard limit of 300 events. If you generate more than 300 public events between daily fetches, some will be lost. The weekly-fetch partially compensates by searching for PRs via the GitHub Search API, but other event types cannot be recovered.
+
+Run the daily fetch consistently to minimize data loss.
+
+### Issues always show 0
+
+Issue collection is not yet implemented. The `issues` field in the report data is always empty. This is a known limitation.
+
+### LLM generation sometimes fails
+
+There is no retry logic for LLM calls. If the provider is down, rate-limited, or the model returns unparseable output, the workflow fails. Re-trigger the Weekly Report workflow manually to try again.
+
+### The default GITHUB_TOKEN does not work
+
+The `GITHUB_TOKEN` provided automatically by GitHub Actions only has access to the current repository. This tool needs to read your activity across all repositories, which requires a personal access token (PAT) stored as the `GH_PAT` secret.
+
+## Cleanup
+
+### How do I stop using this tool?
+
+1. Delete or disable the two workflow files (`daily-fetch.yml` and `weekly-report.yml`)
+2. Optionally delete the `data/` directory from the repository
+3. Delete the `gh-pages` branch to remove the published reports
+4. Revoke the PAT and delete the repository secrets (`GH_PAT` and the LLM API key)
+
+There is no external state or database. Everything is contained in the repository.
+
+### Does data accumulate over time?
+
+Yes, but slowly. Each week adds a few hundred KB of YAML data and one HTML report. Over a year (~52 weeks), expect roughly 10-50 MB. This is well within GitHub's repository and Pages limits.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,126 @@
+# How It Works
+
+## Overview
+
+GitHub Weekly Reporter runs two automated workflows in your repository:
+
+1. **Daily Fetch** runs every night, collecting your GitHub activity
+2. **Weekly Report** runs every Monday, turning that activity into a report
+
+```
+Daily (Mon-Sun, midnight):
+
+  GitHub Events API ──> daily-fetch ──> events.yaml (accumulated)
+
+Weekly (Monday):
+
+  events.yaml ──────────────────────┐
+  GitHub Search API (PR discovery) ─┼──> weekly-fetch ──> github-data.yaml
+  GitHub GraphQL API (stats) ───────┘
+                                         │
+                                         ▼
+                                    generate ──> LLM ──> llm-data.yaml
+                                         │
+                                         ▼
+                                    render ──> HTML, OG images, sitemap
+                                         │
+                                         ▼
+                                    deploy ──> gh-pages branch
+```
+
+## Why Daily Fetch Exists
+
+GitHub's Events API only keeps the most recent 300 events per user, and drops events older than 90 days. Active developers can easily produce more than 300 events in a week.
+
+The daily fetch runs every night to capture events before they expire. Each run merges new events with previously saved ones, so nothing is lost even if the API window slides forward.
+
+If you skip a few days of daily fetching, the weekly step compensates by searching the GitHub Search API for pull requests. But other activity (pushes, reviews, releases) can only be captured through the Events API, so consistent daily fetching gives the most complete report.
+
+Running daily-fetch multiple times in a day is safe. Events are deduplicated by ID.
+
+## The Weekly Pipeline
+
+The Monday workflow runs four steps in sequence. Each step reads the previous step's output, so they must run in order. If any step fails, you can re-run from that step without repeating earlier ones.
+
+### 1. Weekly Fetch
+
+Builds the complete dataset for the week:
+
+- Reads the accumulated daily events
+- Searches GitHub for pull requests you authored or reviewed (catches PRs the daily fetch may have missed)
+- Fetches detailed metadata for each PR (title, description, lines changed, labels)
+- Queries your contribution stats via GraphQL (total commits, daily commit counts for the heatmap, PR review count)
+
+Writes everything to `github-data.yaml`.
+
+### 2. Generate
+
+Sends the week's data to your chosen LLM provider and gets back a structured narrative:
+
+- Title and subtitle for the report
+- A multi-paragraph overview of the week
+- Themed summaries (e.g., "what you built", "code reviews", "patterns")
+- Highlights linking to specific PRs or releases
+
+The data is preprocessed to fit within token limits (up to 20 PRs, 40 events, 8 repositories). The LLM returns YAML, which is parsed and saved as `llm-data.yaml`.
+
+This is the only step that calls an external LLM API. It makes one API call per week.
+
+### 3. Render
+
+Combines the GitHub data and AI content into static files:
+
+- A self-contained HTML report (all CSS inlined, no JavaScript)
+- An OG image for social media sharing
+- An index page listing all past reports
+- A sitemap and robots.txt for search engines
+- A CNAME file if you use a custom domain
+
+The render step also re-renders the previous week's report to add a "next week" navigation link.
+
+### 4. Deploy
+
+Pushes the output to the `gh-pages` branch of your repository. Files from previous weeks are preserved, so all past reports remain accessible.
+
+GitHub Pages serves the site from this branch.
+
+## Which Week Does the Report Cover?
+
+Always the **previous** ISO week (Monday through Sunday). When the workflow runs on Monday, it reports on the week that just ended.
+
+For example, if the workflow runs on Monday April 6, 2026, the report covers March 30 through April 5 (ISO week 14) and is published at `2026/W14/`.
+
+To generate a report for a different week, trigger the workflow manually and set the `date` input to any date within the target week.
+
+## Data Storage
+
+All data is stored in your repository under the `data/` directory:
+
+```
+data/
+  2026/
+    W14/
+      events.yaml         # Daily events, accumulated throughout the week
+      github-data.yaml    # Complete weekly dataset
+      llm-data.yaml       # AI-generated content
+    W15/
+      events.yaml         # Events for the current week (still accumulating)
+```
+
+This data is committed to the main branch by the GitHub Action. It serves as an audit trail and means old reports can be re-rendered without re-fetching expired data.
+
+Storage grows slowly: each week adds a few hundred KB. A year of reports is roughly 10-50 MB.
+
+## What Data Is Collected
+
+The report includes only your **public** GitHub activity:
+
+- Push events (commit messages, branch names)
+- Pull request events (opened, merged, closed)
+- Code review events (approved, changes requested, commented)
+- Issue events (opened, closed)
+- Release events (published)
+- Contribution calendar (daily commit counts, including private contributions if enabled in your GitHub settings)
+- PR details: title, description (truncated to 300 characters), lines changed, labels
+
+Private repository activity is not collected through the Events API, regardless of your token permissions.

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -189,6 +189,17 @@ After the weekly workflow completes, your report is available at:
 https://YOUR_USERNAME.github.io/weekly-report/
 ```
 
+## Generating a Report Manually
+
+After setup, daily fetches run automatically. To generate a weekly report anytime:
+
+1. Go to your repository's **Actions** tab
+2. Click **Weekly Report**
+3. Click **Run workflow**
+4. Optionally set the `date` input to target a specific week (format: `YYYY-MM-DD`)
+
+The report will be built and deployed to GitHub Pages within a few minutes.
+
 ## Configuration Reference
 
 ### Workflow Environment Variables

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,153 @@
+# Troubleshooting
+
+## Workflow Failures
+
+### "GitHub token required" or "GitHub username required"
+
+The `GH_PAT` secret is not set in the repository. The default `GITHUB_TOKEN` provided by GitHub Actions only has access to the current repository and cannot collect your activity across all repos.
+
+**Fix:** Add a PAT as a repository secret named `GH_PAT` in **Settings > Secrets and variables > Actions**. See [What You Need](../README.md#what-you-need) for token requirements.
+
+### "LLM provider required" / "LLM model required" / "LLM API key required"
+
+The weekly report workflow is missing the LLM configuration. All three are required for the `generate` step.
+
+**Fix:** Edit `.github/workflows/weekly-report.yml` and make sure these inputs are set:
+
+```yaml
+with:
+  llm-provider: 'openrouter'
+  llm-model: 'your-model-name'
+  openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+The API key must be stored as a repository secret with the correct name. See [Customization](customization.md#llm-provider-and-model) for provider-specific input and secret names.
+
+### LLM generation fails
+
+Several things can cause this:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Invalid API key | Verify the API key in your repository secrets |
+| `404 model not found` | Wrong model name | Check the provider's model list and use the exact name |
+| `429 rate_limit_exceeded` | Free tier limits hit | Wait and re-trigger, or switch to a different model |
+| `LLM returned empty content` | Model unavailable or response filtered | Retry, or try a different model |
+| YAML parse error | Model returned malformed output | Retry, or try a larger/different model |
+
+There is no automatic retry. Re-trigger the **Weekly Report** workflow manually from the **Actions** tab.
+
+### "permission denied" or git push fails
+
+The workflow does not have write permissions, or two workflows ran at the same time and caused a git conflict.
+
+**Fix:**
+
+1. Make sure both workflow files have the correct permissions:
+   ```yaml
+   permissions:
+     contents: write   # both workflows need this
+     pages: write       # weekly report needs this
+   ```
+
+2. Avoid running daily-fetch and weekly-report at the same time. The default schedule spaces them 1 hour apart to prevent this.
+
+### "GitHub data not found" / "LLM data not found"
+
+The render step cannot find the data files from previous steps. This means an earlier step (fetch or generate) did not run or failed silently.
+
+**Fix:** Go to the **Actions** tab, find the failed run, and check which step failed. The pipeline must run in order: `weekly-fetch` then `generate` then `render`.
+
+## Report Issues
+
+### Report shows no activity or very little data
+
+Several possible causes:
+
+- **First week:** The daily fetch has not accumulated enough data yet. The first report may be sparse because only the weekly search API fallback was available. Reports improve after a full week of daily fetching.
+- **Daily fetch not running:** Check the **Actions** tab to confirm the Daily Fetch workflow is running daily. If the cron never fires, trigger it manually once to verify it works.
+- **Only public events:** The tool only collects public GitHub activity. Commits, PRs, and reviews in private repositories will not appear.
+- **300-event limit:** GitHub's Events API returns at most 300 recent events. If you are very active and the daily fetch missed a day, some events may have been lost.
+
+### Issues count always shows 0
+
+Issue collection is not yet implemented. The report always shows 0 for issues opened/closed. This is a known limitation.
+
+### The report covers the wrong week
+
+The report always covers the **previous** ISO week (Monday through Sunday). If you run the workflow on Monday April 6, it reports on March 30 through April 5.
+
+To generate a report for a specific week, trigger the Weekly Report workflow manually and set the `date` input to any date within the target week (format: `YYYY-MM-DD`).
+
+## GitHub Pages
+
+### Pages not showing after first deploy
+
+- **Wait a few minutes.** The first GitHub Pages deployment can take 2-3 minutes to propagate.
+- **Check that Pages is enabled:** go to **Settings > Pages** and verify the source is set to `gh-pages` branch, `/ (root)` folder.
+- **Check the `gh-pages` branch exists:** the branch is created automatically on first deploy. If the deploy step failed, the branch may not exist yet.
+
+### Pages shows old content
+
+GitHub Pages has a CDN cache. After a deploy, it can take a few minutes for changes to appear. Hard-refresh the page (Ctrl+Shift+R) or wait.
+
+## Setup Command
+
+### "Invalid or expired token"
+
+The PAT you entered is expired, revoked, or malformed.
+
+**Fix:** Generate a new token. For fine-grained PATs: [create one](https://github.com/settings/personal-access-tokens/new) with `All repositories` access and the required permissions. For classic PATs: [create one](https://github.com/settings/tokens/new?scopes=repo,workflow) with `repo` and `workflow` scopes.
+
+### "Token is missing required scopes"
+
+Your classic PAT is missing `repo` or `workflow` scope.
+
+**Fix:** Regenerate the PAT with both scopes enabled. This check does not apply to fine-grained PATs (their permissions are validated later).
+
+### "Failed to set GH_PAT secret"
+
+The setup command could not store the PAT as a repository secret. This usually means the token lacks the `Secrets` permission.
+
+**Fix:**
+- **Fine-grained PAT:** ensure `Secrets: Read and write` permission is granted and `Repository access` is set to `All repositories`.
+- **Classic PAT:** ensure the `repo` scope is granted.
+- **Alternative:** set the secret manually at `https://github.com/<user>/<repo>/settings/secrets/actions`.
+
+### Model validation fails
+
+During setup, the tool makes a test API call to verify the model exists. If it fails:
+
+- **404:** the model name is wrong. Check the provider's model list (the URL is shown in the prompt).
+- **Connection error:** the provider's API is unreachable. Check your network.
+- **Other API error:** the provider may be down. Try again later.
+
+### "Pages may already be enabled or require manual setup"
+
+This is not a fatal error. Setup continues. Enable Pages manually: go to **Settings > Pages**, select `gh-pages` branch, `/ (root)` folder.
+
+### "Could not auto-trigger"
+
+The first weekly report could not be triggered automatically. This happens when the workflow file has not been indexed by GitHub yet (takes a few seconds).
+
+**Fix:** Go to **Actions > Weekly Report > Run workflow** to trigger it manually.
+
+## CLI (Local Usage)
+
+### "Base URL required"
+
+The render command needs a base URL for canonical links and sitemap generation. In GitHub Actions this is auto-derived, but for local usage you must provide it.
+
+**Fix:** `--base-url https://username.github.io/repo-name` or `export BASE_URL=https://username.github.io/repo-name`.
+
+### "Repository required"
+
+The deploy command needs a target repository. In GitHub Actions this is auto-set, but for local usage you must provide it.
+
+**Fix:** `--repo owner/repo` or `export GITHUB_REPOSITORY=owner/repo`.
+
+### "Invalid date format"
+
+The `--date` flag requires the format `YYYY-MM-DD` with zero-padded months and days.
+
+**Fix:** Use `--date 2026-01-05`, not `--date 2026-1-5`.


### PR DESCRIPTION
## Summary

Closes #71

- Restructure README: add Cost section, remove redundant sections (LLM Providers, URL Structure), streamline Prerequisites into "What You Need"
- Add `docs/how-it-works.md`: pipeline overview, data flow, why daily fetch exists, what gets collected
- Add `docs/customization.md`: post-setup configuration reference (site title, language, timezone, LLM provider, custom domain, schedule, version pinning)
- Add `docs/faq.md`: cost, privacy, limitations, cleanup (16 questions)
- Add `docs/troubleshooting.md`: workflow failures, missing data, setup errors, GitHub Pages issues
- Move "Generating a Report Manually" from README to `docs/manual-setup.md`