### PR TITLE
fix: daily-fetch now collects current week events instead of previous week

### DIFF
--- a/src/cli/commands/fetch.test.ts
+++ b/src/cli/commands/fetch.test.ts
@@ -43,6 +43,7 @@ vi.mock("../../collector/aggregate.js", () => ({
 
 vi.mock("../../deployer/week.js", () => ({
   getWeekId: () => ({ year: 2026, week: 14, path: "2026/W14" }),
+  getCurrentWeekId: () => ({ year: 2026, week: 14, path: "2026/W14" }),
 }));
 
 vi.mock("@octokit/graphql", () => ({

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -5,12 +5,12 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { parse as parseYaml, stringify as toYaml } from "yaml";
 import { graphql } from "@octokit/graphql";
-import { buildWeeklyRange, toISODate, parseLocalDate, type DateRange } from "../../collector/date-range.js";
+import { buildWeeklyRange, buildCurrentWeekRange, toISODate, parseLocalDate, type DateRange } from "../../collector/date-range.js";
 import { fetchEvents, dedupeEvents } from "../../collector/fetch-events.js";
 import { fetchContributions } from "../../collector/fetch-contributions.js";
 import { fetchPRsByRefs, type PRRef } from "../../collector/fetch-repo-prs.js";
 import { aggregateRepositories } from "../../collector/aggregate.js";
-import { getWeekId } from "../../deployer/week.js";
+import { getWeekId, getCurrentWeekId } from "../../deployer/week.js";
 import type { GitHubEvent } from "../../types.js";
 
 const env = (key: string): string | undefined => process.env[key];
@@ -59,10 +59,10 @@ export const extractPRRefs = (events: GitHubEvent[]): PRRef[] => {
   return refs;
 };
 
-// daily-fetch: accumulate events
+// daily-fetch: accumulate events for the current week
 const runDailyFetch = async (options: BaseOptions): Promise<void> => {
-  const weekId = getWeekId(options.date, options.timezone);
-  const range = buildWeeklyRange(options.date, options.timezone);
+  const weekId = getCurrentWeekId(options.date, options.timezone);
+  const range = buildCurrentWeekRange(options.date, options.timezone);
   const reportDir = join(options.dataDir, weekId.path);
   await mkdir(reportDir, { recursive: true });
 

--- a/src/collector/date-range.test.ts
+++ b/src/collector/date-range.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildWeeklyRange, toISODate, parseLocalDate } from "./date-range.js";
+import { buildWeeklyRange, buildCurrentWeekRange, toISODate, parseLocalDate } from "./date-range.js";
 
 // Helper: verify the range covers exactly 7 calendar days.
 // In non-DST zones this is 7 * 86400000 - 1 ms.
@@ -363,6 +363,68 @@ describe("buildWeeklyRange", () => {
 
       expect(toISODate(range.to, "Asia/Tokyo")).toBe("2026-03-29");
     });
+  });
+});
+
+// -------------------------------------------------------------------
+// buildCurrentWeekRange
+// -------------------------------------------------------------------
+
+describe("buildCurrentWeekRange", () => {
+  it("returns current ISO week range for the given date (UTC)", () => {
+    // 2026-04-03 is Friday W14 -> current week W14: Mar 30 (Mon) - Apr 3 (today)
+    const now = new Date("2026-04-03T12:00:00Z");
+    const range = buildCurrentWeekRange(now);
+
+    expect(toISODate(range.from)).toBe("2026-03-30");
+    expect(toISODate(range.to)).toBe("2026-04-03");
+  });
+
+  it("on Monday, from and to are both Monday", () => {
+    // 2026-03-30 is Monday W14
+    const now = new Date("2026-03-30T12:00:00Z");
+    const range = buildCurrentWeekRange(now);
+
+    expect(toISODate(range.from)).toBe("2026-03-30");
+    expect(toISODate(range.to)).toBe("2026-03-30");
+  });
+
+  it("on Sunday, covers full Mon-Sun", () => {
+    // 2026-04-05 is Sunday W14
+    const now = new Date("2026-04-05T12:00:00Z");
+    const range = buildCurrentWeekRange(now);
+
+    expect(toISODate(range.from)).toBe("2026-03-30");
+    expect(toISODate(range.to)).toBe("2026-04-05");
+  });
+
+  it("respects Asia/Tokyo timezone", () => {
+    // 2026-04-04 08:00 JST = 2026-04-03 23:00 UTC
+    // JST local: Apr 4 (Sat W14) -> current week: Mar 30 (Mon) - Apr 4 (today)
+    const now = new Date("2026-04-03T23:00:00Z");
+    const range = buildCurrentWeekRange(now, "Asia/Tokyo");
+
+    expect(toISODate(range.from, "Asia/Tokyo")).toBe("2026-03-30");
+    expect(toISODate(range.to, "Asia/Tokyo")).toBe("2026-04-04");
+  });
+
+  it("respects America/New_York timezone", () => {
+    // 2026-04-03 20:00 EDT = 2026-04-04 00:00 UTC
+    // NYC local: Apr 3 (Fri W14) -> current week: Mar 30 (Mon) - Apr 3 (today)
+    const now = new Date("2026-04-04T00:00:00Z");
+    const range = buildCurrentWeekRange(now, "America/New_York");
+
+    expect(toISODate(range.from, "America/New_York")).toBe("2026-03-30");
+    expect(toISODate(range.to, "America/New_York")).toBe("2026-04-03");
+  });
+
+  it("year boundary: first week of 2026", () => {
+    // 2026-01-01 is Thursday W1. Current week: Dec 29 (Mon) - Jan 1 (today)
+    const now = new Date("2026-01-01T12:00:00Z");
+    const range = buildCurrentWeekRange(now);
+
+    expect(toISODate(range.from)).toBe("2025-12-29");
+    expect(toISODate(range.to)).toBe("2026-01-01");
   });
 });
 

--- a/src/collector/date-range.ts
+++ b/src/collector/date-range.ts
@@ -152,6 +152,38 @@ export const buildWeeklyRange = (
   return { from, to };
 };
 
+// Current ISO week range (Monday to now). Used by daily-fetch to accumulate
+// events for the week that is still in progress.
+export const buildCurrentWeekRange = (
+  now: Date = new Date(),
+  timezone: string = "UTC",
+): DateRange => {
+  const { year, month, day } = localDateParts(now, timezone);
+
+  // Find the Monday of the current ISO week
+  const d = new Date(Date.UTC(year, month, day));
+  const dow = d.getUTCDay() || 7; // 1=Mon..7=Sun
+  const thisMonday = new Date(Date.UTC(year, month, day - (dow - 1)));
+
+  const fromParts = {
+    year: thisMonday.getUTCFullYear(),
+    month: thisMonday.getUTCMonth(),
+    day: thisMonday.getUTCDate(),
+  };
+  const from = midnightInTz(fromParts.year, fromParts.month, fromParts.day, timezone);
+
+  // "to" is end of today (next day's midnight - 1ms)
+  const nextDay = new Date(Date.UTC(year, month, day + 1));
+  const toParts = {
+    year: nextDay.getUTCFullYear(),
+    month: nextDay.getUTCMonth(),
+    day: nextDay.getUTCDate(),
+  };
+  const to = new Date(midnightInTz(toParts.year, toParts.month, toParts.day, timezone).getTime() - 1);
+
+  return { from, to };
+};
+
 export const toISODate = (date: Date, timezone: string = "UTC"): string => {
   const fmt = new Intl.DateTimeFormat("en-CA", {
     timeZone: timezone,

--- a/src/deployer/week.test.ts
+++ b/src/deployer/week.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getWeekId } from "./week.js";
+import { getWeekId, getCurrentWeekId } from "./week.js";
 
 describe("getWeekId", () => {
   // -------------------------------------------------------------------
@@ -169,5 +169,54 @@ describe("getWeekId", () => {
       const result = getWeekId(new Date("2026-04-05T14:59:59.999Z"), "Asia/Tokyo");
       expect(result.week).toBe(13);
     });
+  });
+});
+
+describe("getCurrentWeekId", () => {
+  it("returns current ISO week for 2026-04-04 (Sat W14) in UTC -> W14", () => {
+    const result = getCurrentWeekId(new Date("2026-04-04T12:00:00Z"));
+    expect(result.year).toBe(2026);
+    expect(result.week).toBe(14);
+    expect(result.path).toBe("2026/W14");
+  });
+
+  it("returns W14 on Monday (first day of the week)", () => {
+    // 2026-03-30 is Monday W14
+    const result = getCurrentWeekId(new Date("2026-03-30T12:00:00Z"));
+    expect(result.week).toBe(14);
+  });
+
+  it("returns W14 on Sunday (last day of the week)", () => {
+    // 2026-04-05 is Sunday W14
+    const result = getCurrentWeekId(new Date("2026-04-05T12:00:00Z"));
+    expect(result.week).toBe(14);
+  });
+
+  it("current week is one ahead of previous week", () => {
+    const now = new Date("2026-04-04T12:00:00Z");
+    const prev = getWeekId(now);
+    const curr = getCurrentWeekId(now);
+    expect(curr.week).toBe(prev.week + 1);
+  });
+
+  it("year boundary: Jan 1 2026 is in W01", () => {
+    const result = getCurrentWeekId(new Date("2026-01-01T12:00:00Z"));
+    expect(result.year).toBe(2026);
+    expect(result.week).toBe(1);
+    expect(result.path).toBe("2026/W01");
+  });
+
+  it("timezone-aware: same instant, different weeks across week boundary", () => {
+    // 2026-04-05T23:00:00Z = Apr 5 UTC (Sun W14), Apr 6 JST (Mon W15)
+    const utcResult = getCurrentWeekId(new Date("2026-04-05T23:00:00Z"), "UTC");
+    const jstResult = getCurrentWeekId(new Date("2026-04-05T23:00:00Z"), "Asia/Tokyo");
+
+    expect(utcResult.week).toBe(14); // Sunday W14 in UTC
+    expect(jstResult.week).toBe(15); // Monday W15 in JST
+  });
+
+  it("pads single-digit week numbers", () => {
+    const result = getCurrentWeekId(new Date("2026-01-01T12:00:00Z"));
+    expect(result.path).toBe("2026/W01");
   });
 });

--- a/src/deployer/week.ts
+++ b/src/deployer/week.ts
@@ -31,3 +31,20 @@ export const getWeekId = (
   const padded = String(prevWeek).padStart(2, "0");
   return { year: prevYear, week: prevWeek, path: `${prevYear}/W${padded}` };
 };
+
+// Current ISO week ID. Used by daily-fetch to store events for the
+// week that is still in progress.
+export const getCurrentWeekId = (
+  date: Date = new Date(),
+  timezone: string = "UTC",
+): WeekId => {
+  const { year, month, day } = localDateParts(date, timezone);
+  const d = new Date(Date.UTC(year, month, day));
+  const dow = d.getUTCDay() || 7; // 1=Mon..7=Sun
+  // This week's Thursday
+  const thisThursday = new Date(Date.UTC(year, month, day - (dow - 1) + 3));
+  const week = getISOWeekNumber(thisThursday, timezone);
+  const weekYear = localDateParts(thisThursday, timezone).year;
+  const padded = String(week).padStart(2, "0");
+  return { year: weekYear, week, path: `${weekYear}/W${padded}` };
+};


### PR DESCRIPTION
## Summary

- **Bug**: `daily-fetch` was using `buildWeeklyRange` / `getWeekId` which target the **previous** ISO week. When the cron ran mid-week, the GitHub Events API returned 0 events for last week, resulting in an empty `events.yaml` (`[]`).
- **Fix**: Add `buildCurrentWeekRange` and `getCurrentWeekId` for the daily-fetch use case. `weekly-fetch` / `generate` / `render` / `deploy` continue to use the previous-week functions as intended.
- Confirmed the bug via workflow logs on `unhappychoice/weekly-report` (run `23981528192`): `Fetched 0 events` for `2026/W13` when it should have been collecting `W14` (current week).

## Design

| Command | Week Target | Functions Used |
|---------|-------------|----------------|
| `daily-fetch` | **Current** week (accumulate) | `getCurrentWeekId` + `buildCurrentWeekRange` |
| `weekly-fetch` / `generate` / `render` / `deploy` | **Previous** week (report) | `getWeekId` + `buildWeeklyRange` |

## Changed files

- `src/collector/date-range.ts`: add `buildCurrentWeekRange`
- `src/deployer/week.ts`: add `getCurrentWeekId`
- `src/cli/commands/fetch.ts`: switch `runDailyFetch` to current-week functions
- Tests updated for all new functions (13 new test cases)