### PR TITLE
fix: improve PR fetch error handling and document fine-grained PAT 403 issue

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,6 +58,31 @@ The render step cannot find the data files from previous steps. This means an ea
 
 **Fix:** Go to the **Actions** tab, find the failed run, and check which step failed. The pipeline must run in order: `weekly-fetch` then `generate` then `render`.
 
+### "Failed to fetch PR" with 403 Forbidden
+
+When using a fine-grained personal access token (PAT), you may see 403 errors for public repositories in organizations you belong to:
+
+```
+Failed to fetch PR some-org/some-repo#123: 403 Forbidden
+  The 'some-org' organization forbids access via a fine-grained personal access
+  tokens if the token's lifetime is greater than 366 days.
+```
+
+This is a known issue with GitHub's organization token policies. By default, organizations restrict fine-grained PATs with a lifetime exceeding 366 days, and this restriction applies even to public repositories. Non-members are not affected; only members of the organization encounter this block.
+
+GitHub's documentation states that fine-grained PATs "always include read-only access to all public repositories," but the lifetime policy overrides this for organization members. The approval policy correctly exempts public resources, but the lifetime policy does not, which is an inconsistency in GitHub's implementation.
+
+**References:**
+- [composer/composer#12711](https://github.com/composer/composer/issues/12711): Same issue reported by the Composer project
+- [community/community#141929](https://github.com/orgs/community/discussions/141929): GitHub's announcement on PAT lifetime policies
+- [Setting a personal access token policy for your organization](https://docs.github.com/en/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization)
+
+**Fix (choose one):**
+
+1. **Use a classic PAT instead.** Classic PATs with `repo` scope are not subject to the organization lifetime policy. [Create one here.](https://github.com/settings/tokens/new?scopes=repo)
+2. **Change your organization's token policy.** If you are the organization owner, go to **Organization Settings > Personal access tokens > Settings** and either disable the lifetime requirement or increase the maximum allowed lifetime.
+3. **Shorten your token's lifetime.** Recreate the fine-grained PAT with a lifetime of 366 days or less. Note that this means you must rotate the token annually.
+
 ## Report Issues
 
 ### Report shows no activity or very little data

--- a/src/collector/fetch-repo-prs.ts
+++ b/src/collector/fetch-repo-prs.ts
@@ -36,32 +36,72 @@ export type PRRef = {
   number: number;
 };
 
+const MAX_RETRIES = 3;
+const REQUEST_DELAY_MS = 200;
+const DEFAULT_RETRY_DELAY_MS = 5_000;
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+const parseRetryDelay = (response: Response): number => {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (!Number.isNaN(seconds)) return seconds * 1000;
+  }
+  return DEFAULT_RETRY_DELAY_MS;
+};
+
+const readErrorBody = async (response: Response): Promise<string> => {
+  try {
+    const body = (await response.json()) as { message?: string };
+    return body.message ?? "";
+  } catch {
+    return "";
+  }
+};
+
+const toPullRequest = (pr: RawPR, repo: string): PullRequest => ({
+  title: pr.title,
+  body: cleanBody(pr.body),
+  url: pr.html_url,
+  repository: repo,
+  state: mapState(pr.state, pr.merged_at),
+  labels: pr.labels.map((l) => l.name),
+  additions: pr.additions,
+  deletions: pr.deletions,
+  changedFiles: pr.changed_files,
+  author: pr.user?.login ?? "unknown",
+  createdAt: pr.created_at,
+  mergedAt: pr.merged_at,
+});
+
 const fetchSinglePR = async (
   token: string,
   ref: PRRef,
 ): Promise<PullRequest | null> => {
   const url = `https://api.github.com/repos/${ref.repo}/pulls/${ref.number}`;
-  const response = await fetch(url, { headers: GITHUB_HEADERS(token) });
-  if (!response.ok) {
-    console.warn(`Failed to fetch PR ${ref.repo}#${ref.number}: ${response.status} ${response.statusText}`);
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fetch(url, { headers: GITHUB_HEADERS(token) });
+
+    if (response.ok) {
+      return toPullRequest((await response.json()) as RawPR, ref.repo);
+    }
+
+    if (response.status === 429 && attempt < MAX_RETRIES) {
+      const delay = parseRetryDelay(response);
+      console.warn(`  ${ref.repo}#${ref.number}: 429, retrying in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES})`);
+      await sleep(delay);
+      continue;
+    }
+
+    const message = await readErrorBody(response);
+    console.warn(`  Failed to fetch PR ${ref.repo}#${ref.number}: ${response.status} ${response.statusText}`);
+    if (message) console.warn(`    ${message}`);
     return null;
   }
 
-  const pr = (await response.json()) as RawPR;
-  return {
-    title: pr.title,
-    body: cleanBody(pr.body),
-    url: pr.html_url,
-    repository: ref.repo,
-    state: mapState(pr.state, pr.merged_at),
-    labels: pr.labels.map((l) => l.name),
-    additions: pr.additions,
-    deletions: pr.deletions,
-    changedFiles: pr.changed_files,
-    author: pr.user?.login ?? "unknown",
-    createdAt: pr.created_at,
-    mergedAt: pr.merged_at,
-  };
+  return null;
 };
 
 const CONCURRENCY = 5;
@@ -74,7 +114,10 @@ const runWithConcurrency = async <T>(
   const workers = Array.from({ length: CONCURRENCY }, async () => {
     while (queue.length > 0) {
       const item = queue.shift();
-      if (item) await fn(item);
+      if (item) {
+        await fn(item);
+        await sleep(REQUEST_DELAY_MS);
+      }
     }
   });
   await Promise.all(workers);


### PR DESCRIPTION
## Summary

- Retry PR fetches only on 429 (rate limit), not on 403 (permission/policy errors)
- Log the response body message on non-OK responses so users can see the actual cause (e.g. organization lifetime policy)
- Add 200ms inter-request delay to follow [GitHub API best practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#avoid-concurrent-requests)
- Document the fine-grained PAT organization lifetime policy issue in `docs/troubleshooting.md`

## Background

When using a fine-grained PAT with a lifetime exceeding 366 days, GitHub's default organization token policy blocks API access to repositories in organizations the user belongs to, even for public repositories. This causes `403 Forbidden` errors during PR fetching.

The error message from GitHub is:
> The 'org-name' organization forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 366 days.

This is an inconsistency in GitHub's implementation: the approval policy correctly exempts public resources, but the lifetime policy does not. The same issue has been reported in [composer/composer#12711](https://github.com/composer/composer/issues/12711).

Previously, the error was logged as just `403 Forbidden` without the response body, making it impossible for users to diagnose the cause.