### PR TITLE
fix: exclude private repositories from PR search

### DIFF
--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -152,7 +152,7 @@ const searchWeeklyPRs = async (
     let page = 1;
     let hasMore = true;
     while (hasMore) {
-      const q = encodeURIComponent(`is:pr ${qualifier} updated:${from}..${to}`);
+      const q = encodeURIComponent(`is:pr is:public ${qualifier} updated:${from}..${to}`);
       const url = `https://api.github.com/search/issues?q=${q}&per_page=100&page=${page}`;
       const res = await fetch(url, {
         headers: {


### PR DESCRIPTION
## Summary

- Add `is:public` qualifier to the Search API query used during weekly-fetch
- Prevents private repository PRs from leaking into weekly reports published on GitHub Pages

## Background

When using a PAT with `repo` scope, the Search API (`/search/issues`) returns results from both public and private repositories. Since reports are deployed to GitHub Pages (public), private repository names, PR titles, and details should not be included.

The Events API path was already safe (filtered by `.filter(e => e.public)` in `fetch-events.ts`), but the Search API fallback in `searchWeeklyPRs` had no visibility filter.