### PR TITLE
fix: exclude incomplete weeks from index page and navigation

### DIFF
--- a/src/cli/commands/render.test.ts
+++ b/src/cli/commands/render.test.ts
@@ -6,12 +6,14 @@ const mockReadFile = vi.fn();
 const mockWriteFile = vi.fn();
 const mockReaddir = vi.fn();
 const mockMkdir = vi.fn();
+const mockAccess = vi.fn();
 
 vi.mock("node:fs/promises", () => ({
   readFile: (...args: unknown[]) => mockReadFile(...args),
   writeFile: (...args: unknown[]) => mockWriteFile(...args),
   readdir: (...args: unknown[]) => mockReaddir(...args),
   mkdir: (...args: unknown[]) => mockMkdir(...args),
+  access: (...args: unknown[]) => mockAccess(...args),
 }));
 
 // Mock renderer
@@ -80,6 +82,8 @@ describe("registerRender", () => {
     vi.clearAllMocks();
     mockWriteFile.mockResolvedValue(undefined);
     mockMkdir.mockResolvedValue(undefined);
+    // Default: llm-data.yaml exists for all directories
+    mockAccess.mockResolvedValue(undefined);
     vi.spyOn(process, "exit").mockImplementation((() => { throw new Error("process.exit"); }) as never);
   });
 
@@ -310,6 +314,11 @@ describe("registerRender", () => {
       if (path.includes("llm-data.yaml")) return Promise.resolve(LLM_DATA_YAML);
       return Promise.reject(new Error("not found"));
     });
+
+    // W13 has no llm-data.yaml
+    mockAccess.mockImplementation((path: string) =>
+      path.includes("W13") ? Promise.reject(new Error("not found")) : Promise.resolve(undefined),
+    );
 
     mockReaddir.mockImplementation((dir: string) => {
       if (dir.endsWith("data")) return Promise.resolve(["2026"]);

--- a/src/cli/commands/render.ts
+++ b/src/cli/commands/render.ts
@@ -1,7 +1,7 @@
 // render command: read github-data.yaml + llm-data.yaml and produce HTML
 
 import { Command } from "commander";
-import { readFile, writeFile, readdir, mkdir } from "node:fs/promises";
+import { readFile, writeFile, readdir, mkdir, access } from "node:fs/promises";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { renderReport } from "../../renderer/index.js";
@@ -23,7 +23,11 @@ type RenderOptions = {
   date?: Date;
 };
 
-const listReportDirs = async (dir: string): Promise<string[]> => {
+const fileExists = async (path: string): Promise<boolean> => {
+  try { await access(path); return true; } catch { return false; }
+};
+
+const listCompletedReportDirs = async (dir: string): Promise<string[]> => {
   const paths: string[] = [];
   let entries: string[];
   try {
@@ -33,9 +37,11 @@ const listReportDirs = async (dir: string): Promise<string[]> => {
   }
   for (const year of entries.filter((n) => /^\d{4}$/.test(n))) {
     const weeks = await readdir(join(dir, year));
-    weeks
-      .filter((n) => /^W\d{2}$/.test(n))
-      .forEach((w) => paths.push(`${year}/${w}`));
+    for (const w of weeks.filter((n) => /^W\d{2}$/.test(n))) {
+      if (await fileExists(join(dir, year, w, "llm-data.yaml"))) {
+        paths.push(`${year}/${w}`);
+      }
+    }
   }
   return paths;
 };
@@ -52,21 +58,24 @@ const tryReadYaml = async <T>(path: string): Promise<T | null> => {
 const buildReportEntries = async (
   dataDir: string,
   reportPaths: string[],
-): Promise<ReportEntry[]> =>
-  Promise.all(
+): Promise<ReportEntry[]> => {
+  const entries = await Promise.all(
     reportPaths.map(async (path) => {
       const [llmData, ghData] = await Promise.all([
         tryReadYaml<AIContent>(join(dataDir, path, "llm-data.yaml")),
         tryReadYaml<WeeklyReportData>(join(dataDir, path, "github-data.yaml")),
       ]);
+      if (!llmData) return null;
       const stats = ghData ? {
         commits: ghData.stats.totalCommits,
         prs: ghData.stats.prsOpened,
         reviews: ghData.stats.prsReviewed,
       } : undefined;
-      return buildReportEntry(path, llmData?.title, llmData?.subtitle, stats);
+      return buildReportEntry(path, llmData.title, llmData.subtitle, stats);
     }),
   );
+  return entries.filter((e): e is ReportEntry => e !== null);
+};
 
 const run = async (options: RenderOptions): Promise<void> => {
   const weekId = getWeekId(options.date, options.timezone);
@@ -92,7 +101,7 @@ const run = async (options: RenderOptions): Promise<void> => {
   const data: WeeklyReportData = { ...githubData, aiContent };
 
   // Determine prev/next week paths for internal linking
-  const allPaths = (await listReportDirs(options.dataDir)).sort();
+  const allPaths = (await listCompletedReportDirs(options.dataDir)).sort();
   if (!allPaths.includes(weekId.path)) allPaths.push(weekId.path);
   allPaths.sort();
   const currentIdx = allPaths.indexOf(weekId.path);


### PR DESCRIPTION
## Summary

- Only include weeks with `llm-data.yaml` (completed reports) in the index page, prev/next navigation links, and sitemap
- Prevents broken links on the index page for weeks that only have `events.yaml` from daily-fetch

## Background

When `daily-fetch` runs, it creates a directory like `data/2026/W14/events.yaml` for the current week. When `weekly-report` then runs and renders the previous week (W13), the `listReportDirs` function would pick up W14 as well, even though it has no completed report. This caused a broken link on the index page pointing to a non-existent W14 report.

Now `listCompletedReportDirs` checks for the existence of `llm-data.yaml` before including a week in the list. The `buildReportEntries` function also filters out entries where `llm-data.yaml` is missing.