### PR TITLE
feat: set homepage URL and topics on repository during setup

### DIFF
--- a/src/cli/commands/setup.test.ts
+++ b/src/cli/commands/setup.test.ts
@@ -18,6 +18,7 @@ vi.mock("@inquirer/prompts", () => ({
 
 const mockValidateToken = vi.fn();
 const mockEnsureRepo = vi.fn();
+const mockSetRepoTopics = vi.fn();
 const mockAddFileToRepo = vi.fn();
 const mockEnablePages = vi.fn();
 const mockSetRepoSecret = vi.fn();
@@ -28,6 +29,7 @@ const mockSleep = vi.fn();
 vi.mock("./setup/github-api.js", () => ({
   validateToken: (...args: unknown[]) => mockValidateToken(...args),
   ensureRepo: (...args: unknown[]) => mockEnsureRepo(...args),
+  setRepoTopics: (...args: unknown[]) => mockSetRepoTopics(...args),
   addFileToRepo: (...args: unknown[]) => mockAddFileToRepo(...args),
   enablePages: (...args: unknown[]) => mockEnablePages(...args),
   setRepoSecret: (...args: unknown[]) => mockSetRepoSecret(...args),
@@ -238,6 +240,7 @@ const setupPromptDefaults = () => {
 
   // setup actions
   mockEnsureRepo.mockResolvedValue(true);
+  mockSetRepoTopics.mockResolvedValue(undefined);
   mockSetRepoSecret.mockResolvedValue(true);
   mockAddFileToRepo.mockResolvedValue(undefined);
   mockEnablePages.mockResolvedValue("https://testuser.github.io/my-reports");
@@ -272,6 +275,9 @@ describe("registerSetup (full flow)", () => {
 
     // Created repo
     expect(mockEnsureRepo).toHaveBeenCalledWith("ghp_testtoken123", "testuser/my-reports");
+
+    // Set topics
+    expect(mockSetRepoTopics).toHaveBeenCalledWith("ghp_testtoken123", "testuser/my-reports");
 
     // Set GH_PAT secret
     expect(mockSetRepoSecret).toHaveBeenCalledWith(
@@ -326,6 +332,7 @@ describe("registerSetup (full flow)", () => {
     mockValidateModel.mockResolvedValue({ valid: true });
     mockConfirm.mockResolvedValue(true);
     mockEnsureRepo.mockResolvedValue(false);
+    mockSetRepoTopics.mockResolvedValue(undefined);
     mockSetRepoSecret.mockResolvedValue(true);
     mockAddFileToRepo.mockResolvedValue(undefined);
     mockEnablePages.mockResolvedValue("https://testuser.github.io/existing-repo");
@@ -407,6 +414,7 @@ describe("registerSetup (full flow)", () => {
       .mockResolvedValueOnce(true)  // retry model
       .mockResolvedValueOnce(true); // proceed with setup
     mockEnsureRepo.mockResolvedValue(true);
+    mockSetRepoTopics.mockResolvedValue(undefined);
     mockSetRepoSecret.mockResolvedValue(true);
     mockAddFileToRepo.mockResolvedValue(undefined);
     mockEnablePages.mockResolvedValue("https://testuser.github.io/my-reports");
@@ -447,6 +455,7 @@ describe("registerSetup (full flow)", () => {
     mockValidateModel.mockResolvedValue({ valid: true });
     mockConfirm.mockResolvedValue(true);
     mockEnsureRepo.mockResolvedValue(true);
+    mockSetRepoTopics.mockResolvedValue(undefined);
     mockSetRepoSecret.mockResolvedValue(true);
     mockAddFileToRepo.mockResolvedValue(undefined);
     mockEnablePages.mockResolvedValue("https://testuser.github.io/my-reports");

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -3,7 +3,7 @@
 import { Command } from "commander";
 import { input, select, password, confirm } from "@inquirer/prompts";
 import type { LLMProvider, Language } from "../../types.js";
-import { validateToken, ensureRepo, addFileToRepo, enablePages, setRepoSecret, ghGet, ghPost, sleep } from "./setup/github-api.js";
+import { validateToken, ensureRepo, setRepoTopics, addFileToRepo, enablePages, setRepoSecret, ghGet, ghPost, sleep } from "./setup/github-api.js";
 import { midnightCronUTC, buildDailyWorkflow, buildWeeklyWorkflow, buildReadme, LLM_SECRET_NAMES } from "./setup/workflows.js";
 import type { WorkflowOpts } from "./setup/workflows.js";
 import { TIMEZONE_CHOICES, LANGUAGE_CHOICES, MODEL_LIST_URLS } from "./setup/constants.js";
@@ -218,6 +218,8 @@ const run = async (cliRepo?: string): Promise<void> => {
   step("Setting up repository...");
   const created = await ensureRepo(config.token, fullRepo);
   ok(created ? `Created ${fullRepo}` : `Using existing ${fullRepo}`);
+  await setRepoTopics(config.token, fullRepo);
+  ok("Topics configured.");
 
   // 2. PAT secret (needed to read activity across all repos)
   step("Setting secret GH_PAT...");

--- a/src/cli/commands/setup/github-api.test.ts
+++ b/src/cli/commands/setup/github-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { validateToken, ensureRepo, addFileToRepo, enablePages, setRepoSecret, sleep, ghGet, ghPost, ghPut } from "./github-api.js";
+import { validateToken, ensureRepo, setRepoTopics, addFileToRepo, enablePages, setRepoSecret, sleep, ghGet, ghPost, ghPut } from "./github-api.js";
 
 describe("github-api", () => {
   beforeEach(() => {
@@ -105,13 +105,18 @@ describe("github-api", () => {
     });
 
     it("creates user repo when owner matches login", async () => {
-      vi.spyOn(globalThis, "fetch")
+      const fetchSpy = vi.spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(new Response("", { status: 404 })) // repo doesn't exist
         .mockResolvedValueOnce(new Response(JSON.stringify({ login: "user" }), { status: 200 })) // /user
         .mockResolvedValueOnce(new Response("", { status: 201 })); // create repo
 
       const result = await ensureRepo("token", "user/repo");
       expect(result).toBe(true);
+
+      // Verify homepage is set in the create request
+      const createCall = fetchSpy.mock.calls[2];
+      const body = JSON.parse(createCall[1]!.body as string);
+      expect(body.homepage).toBe("https://user.github.io/repo");
     });
 
     it("creates org repo when owner differs from login", async () => {
@@ -134,6 +139,29 @@ describe("github-api", () => {
         .mockResolvedValueOnce(new Response("error details", { status: 422 }));
 
       await expect(ensureRepo("token", "user/repo")).rejects.toThrow("Failed to create user/repo");
+    });
+  });
+
+  describe("setRepoTopics", () => {
+    it("sends PUT request with topic names", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("", { status: 200 }),
+      );
+      await setRepoTopics("token", "user/repo");
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://api.github.com/repos/user/repo/topics",
+        expect.objectContaining({
+          method: "PUT",
+          body: expect.stringContaining("github-weekly-reporter"),
+        }),
+      );
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+      expect(body.names).toEqual(expect.arrayContaining([
+        "github-weekly-reporter",
+        "weekly-report",
+        "github-activity",
+        "github-pages",
+      ]));
     });
   });
 

--- a/src/cli/commands/setup/github-api.ts
+++ b/src/cli/commands/setup/github-api.ts
@@ -134,31 +134,44 @@ export const ensureRepo = async (
     login: string;
   };
 
+  const homepage = `https://${owner}.github.io/${name}`;
+  const body = {
+    name,
+    auto_init: true,
+    private: false,
+    description: "Weekly GitHub activity reports",
+    homepage,
+  };
+
   const createRes =
     owner === login
-      ? await ghPost(token, "/user/repos", {
-          name,
-          auto_init: true,
-          private: false,
-          description: "Weekly GitHub activity reports",
-        })
-      : await ghPost(token, `/orgs/${owner}/repos`, {
-          name,
-          auto_init: true,
-          private: false,
-          description: "Weekly GitHub activity reports",
-        });
+      ? await ghPost(token, "/user/repos", body)
+      : await ghPost(token, `/orgs/${owner}/repos`, body);
 
   if (!createRes.ok) {
-    const body = await createRes.text();
+    const errBody = await createRes.text();
     throw new Error(
-      `Failed to create ${fullRepo}: ${createRes.status}\n  ${body}`,
+      `Failed to create ${fullRepo}: ${createRes.status}\n  ${errBody}`,
     );
   }
 
   // Wait for repo to be ready
   await new Promise((r) => setTimeout(r, 2000));
   return true;
+};
+
+const REPO_TOPICS = [
+  "github-weekly-reporter",
+  "weekly-report",
+  "github-activity",
+  "github-pages",
+];
+
+export const setRepoTopics = async (
+  token: string,
+  repo: string,
+): Promise<void> => {
+  await ghPut(token, `/repos/${repo}/topics`, { names: REPO_TOPICS });
 };
 
 export const addFileToRepo = async (


### PR DESCRIPTION
## Summary

- `ensureRepo()` now sets the `homepage` field (GitHub Pages URL) when creating a repository via the GitHub API
- Added `setRepoTopics()` to configure discoverable topics (`github-weekly-reporter`, `weekly-report`, `github-activity`, `github-pages`) on both new and existing repositories
- Topics are set right after repo creation/confirmation in the setup flow