### PR TITLE
fix: improve error handling, UX, and i18n across CLI and collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Every week, this tool looks at everything you did on GitHub (commits, pull reque
 
 Have these two things ready before running setup:
 
-1. **GitHub fine-grained PAT** with `All repositories` access and these permissions (all Read & Write):
-   `Actions`, `Administration`, `Contents`,  `Pages`, `Secrets`, `Workflows`
-   ([Create one](https://github.com/settings/personal-access-tokens/new))
+1. **GitHub personal access token (PAT)**, either type works:
+
+   - **Fine-grained PAT** (recommended): `All repositories` access with permissions: `Actions`, `Administration`, `Contents`, `Pages`, `Secrets`, `Workflows` (all Read & Write).
+     ([Create one](https://github.com/settings/personal-access-tokens/new))
+   - **Classic PAT**: scopes `repo` and `workflow`.
+     ([Create one](https://github.com/settings/tokens/new?scopes=repo,workflow))
+     Use this if you hit 403 errors with fine-grained tokens (e.g. org policy restrictions).
 
 2. **LLM API key** from any supported provider:
 

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -161,7 +161,15 @@ const searchWeeklyPRs = async (
           "User-Agent": "github-weekly-reporter",
         },
       });
-      if (!res.ok) break;
+      if (!res.ok) {
+        if (res.status === 401 || res.status === 403) {
+          throw new Error(
+            `GitHub Search API returned ${res.status}. Check that your token (GH_PAT) is valid.`,
+          );
+        }
+        console.warn(`  Search API error (${res.status}), some PRs may be missing.`);
+        break;
+      }
       const data = (await res.json()) as {
         items: { number: number; pull_request?: { url: string }; repository_url: string }[];
         total_count: number;

--- a/src/cli/commands/render.ts
+++ b/src/cli/commands/render.ts
@@ -228,7 +228,7 @@ export const registerRender = (program: Command): void => {
     .option("-o, --output-dir <dir>", "Output directory for HTML (env: OUTPUT_DIR, default: ./output)")
     .option("--base-url <url>", "Base URL for absolute links in OG tags, sitemap, canonical (env: BASE_URL)")
     .option("--site-title <title>", "Site title for nav header (env: SITE_TITLE, default: {username}'s Weekly Reports)")
-    .option("--language <lang>", "Report language: en, ja (env: LANGUAGE, default: en)")
+    .option("--language <lang>", "Report language: en, ja, zh-CN, zh-TW, ko, es, fr, de, pt, ru (env: LANGUAGE, default: en)")
     .option("--timezone <tz>", "IANA timezone (env: TIMEZONE, default: UTC)")
     .option("--date <date>", "Date within the target week (YYYY-MM-DD, default: today)")
     .action(async (opts) => {

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -8,6 +8,7 @@ import { midnightCronUTC, buildDailyWorkflow, buildWeeklyWorkflow, buildReadme, 
 import type { WorkflowOpts } from "./setup/workflows.js";
 import { TIMEZONE_CHOICES, LANGUAGE_CHOICES, MODEL_LIST_URLS } from "./setup/constants.js";
 import { validateModel } from "./setup/validate-model.js";
+import { withSpinner } from "../spinner.js";
 
 // Re-export for tests and external consumers
 export { midnightCronUTC, buildDailyWorkflow, buildWeeklyWorkflow } from "./setup/workflows.js";
@@ -46,8 +47,7 @@ const collectInputs = async (cliRepo?: string): Promise<SetupConfig> => {
     validate: (v) => (v.length > 0 ? true : "Token is required"),
   });
 
-  console.log("\n  Validating token...");
-  const { login } = await validateToken(token);
+  const { login } = await withSpinner("Validating token...", () => validateToken(token));
   console.log(`  Authenticated as ${login}\n`);
 
   // 2. Username
@@ -149,10 +149,9 @@ const collectInputs = async (cliRepo?: string): Promise<SetupConfig> => {
         validate: (v) => (v.length > 0 ? true : "Model name is required"),
       });
 
-      console.log("  Validating model...");
-      const result = await validateModel(llmProvider, llmApiKey, llmModel);
+      const result = await withSpinner("Validating model...", () => validateModel(llmProvider, llmApiKey!, llmModel!));
       if (result.valid) {
-        console.log("  Model OK.\n");
+        console.log("");
         modelValidated = true;
       } else {
         console.log(`  ${result.error}`);
@@ -195,7 +194,7 @@ const run = async (cliRepo?: string): Promise<void> => {
   console.log("\n  ── Setup Summary ─────────────────────────────");
   console.log(`  Repository:    ${fullRepo}`);
   console.log(`  Username:      ${config.username}`);
-  console.log(`  Site title:    ${config.siteTitle}`);
+  console.log(`  Site title:    ${config.siteTitle.replace(/\\n/g, " ")}`);
   console.log(`  Language:      ${config.language}`);
   console.log(`  Timezone:      ${config.timezone}`);
   console.log(`  Schedule:      Daily at midnight (cron: ${cron})`);

--- a/src/cli/commands/setup/github-api.ts
+++ b/src/cli/commands/setup/github-api.ts
@@ -192,7 +192,12 @@ export const addFileToRepo = async (
     ...(sha ? { sha } : {}),
   });
   if (!res.ok) {
-    throw new Error(`Failed to add ${path}: ${res.status}`);
+    const hint = res.status === 403
+      ? "\n\n  Possible causes:" +
+        "\n    - Fine-grained PAT: ensure 'Contents: Read and write' and 'Workflows: Read and write' permissions" +
+        "\n    - Classic PAT: ensure 'repo' and 'workflow' scopes are granted"
+      : "";
+    throw new Error(`Failed to add ${path}: ${res.status}${hint}`);
   }
 };
 

--- a/src/cli/commands/setup/validate-model.test.ts
+++ b/src/cli/commands/setup/validate-model.test.ts
@@ -109,4 +109,14 @@ describe("validateModel", () => {
     expect(result.valid).toBe(false);
     expect(result.error).toContain("API error: 500");
   });
+
+  it("does not false-positive on error body that mentions 'model' without 'not found'", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"error": "The model is currently overloaded"}', { status: 503 }),
+    );
+    const result = await validateModel("openai", "key", "gpt-4");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("API error: 503");
+    expect(result.error).not.toContain("not found");
+  });
 });

--- a/src/cli/commands/setup/validate-model.ts
+++ b/src/cli/commands/setup/validate-model.ts
@@ -71,8 +71,9 @@ export const validateModel = async (
     if (res.ok) return { valid: true };
 
     const body = await res.text();
-    // 404 or "model not found" means wrong model name
-    if (res.status === 404 || body.toLowerCase().includes("model")) {
+    const lower = body.toLowerCase();
+    // 404 or explicit "not found" in body means wrong model name
+    if (res.status === 404 || lower.includes("not_found") || lower.includes("not found")) {
       return { valid: false, error: `Model "${model}" not found (${res.status})` };
     }
     // Rate limit or other non-model errors are fine (model exists)

--- a/src/cli/commands/setup/workflows.ts
+++ b/src/cli/commands/setup/workflows.ts
@@ -27,12 +27,17 @@ const LLM_API_KEY_INPUT_NAMES: Record<string, string> = {
 // GitHub Actions cron is always UTC, so we calculate the offset.
 
 export const midnightCronUTC = (timezone: string): string => {
-  const now = new Date();
+  // Use Jan 1 (standard time) to avoid DST-dependent offset.
+  // During DST the cron fires ~1h late (e.g. 01:00 local), which is safe
+  // because daily-fetch resolves "yesterday" from the local date.
+  // The opposite (firing 1h early = 23:00 the previous day) would shift
+  // the local date backward and collect the wrong day.
+  const jan1 = new Date(new Date().getFullYear(), 0, 1, 0, 0, 0);
   const utcMidnight = new Date(
-    now.toLocaleString("en-US", { timeZone: "UTC" }),
+    jan1.toLocaleString("en-US", { timeZone: "UTC" }),
   );
   const localMidnight = new Date(
-    now.toLocaleString("en-US", { timeZone: timezone }),
+    jan1.toLocaleString("en-US", { timeZone: timezone }),
   );
   const offsetMinutes = Math.round(
     (utcMidnight.getTime() - localMidnight.getTime()) / 60000,
@@ -151,7 +156,9 @@ export const buildReadme = (opts: {
   timezone: string;
   llmProvider?: LLMProvider;
   llmModel?: string;
-}): string => `# ${opts.siteTitle}
+}): string => {
+  const displayTitle = opts.siteTitle.replace(/\\n/g, " ");
+  return `# ${displayTitle}
 
 Weekly GitHub activity reports for [@${opts.username}](https://github.com/${opts.username}), powered by [github-weekly-reporter](https://github.com/deariary/github-weekly-reporter).
 
@@ -174,7 +181,7 @@ Edit \`.github/workflows/weekly-report.yml\` to change:
 | \`username\` | \`${opts.username}\` | GitHub user to report on |
 | \`language\` | \`${opts.language}\` | Report language (en, ja, zh-CN, zh-TW, ko, es, fr, de, pt, ru) |
 | \`timezone\` | \`${opts.timezone}\` | IANA timezone for date calculations |
-| \`SITE_TITLE\` | \`${opts.siteTitle}\` | Site title in the header and hero |
+| \`SITE_TITLE\` | \`${displayTitle}\` | Site title in the header and hero |
 ${opts.llmProvider ? `| \`llm-provider\` | \`${opts.llmProvider}\` | LLM provider for AI narrative |\n| \`llm-model\` | \`${opts.llmModel}\` | Model name |\n` : ""}
 ## Base URL
 
@@ -208,3 +215,4 @@ Go to [Actions](https://github.com/${opts.repo}/actions), click **Weekly Report*
 
 Supported by [deariary](https://deariary.com)
 `;
+};

--- a/src/cli/spinner.ts
+++ b/src/cli/spinner.ts
@@ -1,0 +1,29 @@
+// Minimal CLI spinner (no external dependencies)
+
+const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const INTERVAL = 80;
+
+export const withSpinner = async <T>(message: string, task: () => Promise<T>): Promise<T> => {
+  // Skip animation in non-TTY environments (CI, piped output, tests)
+  if (!process.stderr.isTTY) {
+    process.stderr.write(`  ${message}\n`);
+    return task();
+  }
+
+  let i = 0;
+  const timer = setInterval(() => {
+    const frame = FRAMES[i++ % FRAMES.length];
+    process.stderr.write(`\r  ${frame} ${message}`);
+  }, INTERVAL);
+
+  try {
+    const result = await task();
+    clearInterval(timer);
+    process.stderr.write(`\r  ✔ ${message}\n`);
+    return result;
+  } catch (error) {
+    clearInterval(timer);
+    process.stderr.write(`\r  ✖ ${message}\n`);
+    throw error;
+  }
+};

--- a/src/collector/fetch-events.test.ts
+++ b/src/collector/fetch-events.test.ts
@@ -247,9 +247,29 @@ describe("fetchEvents", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("handles API error gracefully", async () => {
+  it("throws on 401 authentication error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("", { status: 401, statusText: "Unauthorized" }),
+    );
+
+    await expect(fetchEvents("token", "testuser", range)).rejects.toThrow(
+      /GitHub API returned 401/,
+    );
+  });
+
+  it("throws on 403 forbidden error", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response("", { status: 403, statusText: "Forbidden" }),
+    );
+
+    await expect(fetchEvents("token", "testuser", range)).rejects.toThrow(
+      /GitHub API returned 403/,
+    );
+  });
+
+  it("handles other API errors gracefully", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("", { status: 500, statusText: "Internal Server Error" }),
     );
 
     const result = await fetchEvents("token", "testuser", range);

--- a/src/collector/fetch-events.ts
+++ b/src/collector/fetch-events.ts
@@ -15,6 +15,8 @@ type RawEvent = {
 
 const EVENTS_PER_PAGE = 100;
 const MAX_PAGES = 3; // GitHub Events API hard limit is 300 events (3 pages)
+const MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 5_000;
 
 export const summarizePayload = (type: string, raw: Record<string, unknown>): EventPayload => {
   switch (type) {
@@ -67,26 +69,56 @@ export const summarizePayload = (type: string, raw: Record<string, unknown>): Ev
   }
 };
 
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+const parseRetryDelay = (response: Response): number => {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (!Number.isNaN(seconds)) return seconds * 1000;
+  }
+  return DEFAULT_RETRY_DELAY_MS;
+};
+
 const fetchPage = async (
   token: string,
   username: string,
   page: number,
 ): Promise<RawEvent[]> => {
   const url = `https://api.github.com/users/${username}/events?per_page=${EVENTS_PER_PAGE}&page=${page}`;
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "github-weekly-reporter",
-    },
-  });
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "github-weekly-reporter",
+  };
 
-  if (!response.ok) {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fetch(url, { headers });
+
+    if (response.ok) {
+      return (await response.json()) as RawEvent[];
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        `GitHub API returned ${response.status} ${response.statusText}. ` +
+        "Check that your token (GH_PAT) is valid and not expired.",
+      );
+    }
+
+    if (response.status === 429 && attempt < MAX_RETRIES) {
+      const delay = parseRetryDelay(response);
+      console.warn(`Rate limited on events page ${page}, retrying in ${Math.round(delay / 1000)}s (attempt ${attempt + 1}/${MAX_RETRIES})`);
+      await sleep(delay);
+      continue;
+    }
+
     console.warn(`Failed to fetch events page ${page}: ${response.status} ${response.statusText}`);
     return [];
   }
-  return (await response.json()) as RawEvent[];
+
+  return [];
 };
 
 export const isInRange = (eventDate: string, range: DateRange): boolean => {
@@ -101,8 +133,10 @@ export const fetchEvents = async (
 ): Promise<GitHubEvent[]> => {
   const events: GitHubEvent[] = [];
 
+  let lastPageSize = 0;
   for (let page = 1; page <= MAX_PAGES; page++) {
     const raw = await fetchPage(token, username, page);
+    lastPageSize = raw.length;
     if (raw.length === 0) break;
 
     raw
@@ -120,6 +154,10 @@ export const fetchEvents = async (
 
     const oldest = raw[raw.length - 1];
     if (oldest && new Date(oldest.created_at).getTime() < range.from.getTime()) break;
+  }
+
+  if (lastPageSize === EVENTS_PER_PAGE) {
+    console.warn("Warning: GitHub Events API limit reached (300 events). Some events may be missing.");
   }
 
   return events;

--- a/src/collector/fetch-repo-prs.ts
+++ b/src/collector/fetch-repo-prs.ts
@@ -134,11 +134,17 @@ export const fetchPRsByRefs = async (
   });
 
   const prs: PullRequest[] = [];
+  let failed = 0;
 
   await runWithConcurrency([...unique.values()], async (ref) => {
     const pr = await fetchSinglePR(token, ref);
     if (pr) prs.push(pr);
+    else failed++;
   });
+
+  if (failed > 0) {
+    console.warn(`Warning: ${failed} of ${unique.size} PRs could not be fetched.`);
+  }
 
   return prs;
 };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -134,7 +134,7 @@ const ko: Locale = {
 };
 
 const es: Locale = {
-  weekdaysShort: ["Dom", "Lun", "Mar", "Mie", "Jue", "Vie", "Sab"],
+  weekdaysShort: ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"],
   sectionSummary: "Resumen",
   sectionHighlights: "Destacados",
   allWeeks: "Todas las semanas",
@@ -152,10 +152,10 @@ const es: Locale = {
 
 const fr: Locale = {
   weekdaysShort: ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"],
-  sectionSummary: "Resume",
+  sectionSummary: "Résumé",
   sectionHighlights: "Points forts",
   allWeeks: "Toutes les semaines",
-  prevWeek: "Semaine precedente",
+  prevWeek: "Semaine précédente",
   nextWeek: "Semaine suivante",
   share: "Partager",
   poweredBy: "Powered by",
@@ -163,7 +163,7 @@ const fr: Locale = {
   weeklyReports: "Rapports hebdomadaires",
   weeklyReport: "Rapport hebdomadaire",
   sectionsCount: (n) => `${n} sections`,
-  itemsCount: (n) => `${n} elements`,
+  itemsCount: (n) => `${n} éléments`,
   userWeek: (u) => `Semaine de ${u}`,
 };
 
@@ -173,30 +173,30 @@ const de: Locale = {
   sectionHighlights: "Highlights",
   allWeeks: "Alle Wochen",
   prevWeek: "Vorherige Woche",
-  nextWeek: "Naechste Woche",
+  nextWeek: "Nächste Woche",
   share: "Teilen",
   poweredBy: "Powered by",
   generatedWith: "Generated with",
   weeklyReports: "Wochenberichte",
   weeklyReport: "Wochenbericht",
   sectionsCount: (n) => `${n} Abschnitte`,
-  itemsCount: (n) => `${n} Eintraege`,
+  itemsCount: (n) => `${n} Einträge`,
   userWeek: (u) => `${u}s Woche`,
 };
 
 const pt: Locale = {
-  weekdaysShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"],
+  weekdaysShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"],
   sectionSummary: "Resumo",
   sectionHighlights: "Destaques",
   allWeeks: "Todas as semanas",
   prevWeek: "Semana anterior",
-  nextWeek: "Proxima semana",
+  nextWeek: "Próxima semana",
   share: "Compartilhar",
   poweredBy: "Powered by",
   generatedWith: "Generated with",
-  weeklyReports: "Relatorios semanais",
-  weeklyReport: "Relatorio semanal",
-  sectionsCount: (n) => `${n} secoes`,
+  weeklyReports: "Relatórios semanais",
+  weeklyReport: "Relatório semanal",
+  sectionsCount: (n) => `${n} seções`,
   itemsCount: (n) => `${n} itens`,
   userWeek: (u) => `Semana de ${u}`,
 };

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -130,6 +130,10 @@ export const generateContent = async (
     return resolveHighlightUrls(content, input.pullRequests, input.issues, input.events);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`LLM content generation failed (${config.provider}): ${message}`, { cause: error });
+    const isParseError = message.includes("YAML") || message.includes("parse");
+    const hint = isParseError
+      ? " The LLM returned malformed output. Retry the command, or try a larger/different model."
+      : "";
+    throw new Error(`LLM content generation failed (${config.provider}): ${message}${hint}`, { cause: error });
   }
 };

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1,7 +1,7 @@
 // Anthropic provider implementation
 
 import Anthropic from "@anthropic-ai/sdk";
-import { DEFAULT_MAX_TOKENS, type LLMProvider, type LLMConfig } from "../types.js";
+import { DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE, type LLMProvider, type LLMConfig } from "../types.js";
 
 export const createAnthropicProvider = (config: LLMConfig): LLMProvider => {
   const client = new Anthropic({ apiKey: config.apiKey });
@@ -11,6 +11,7 @@ export const createAnthropicProvider = (config: LLMConfig): LLMProvider => {
       const response = await client.messages.create({
         model: config.model,
         max_tokens: DEFAULT_MAX_TOKENS,
+        temperature: DEFAULT_TEMPERATURE,
         messages: [{ role: "user", content: prompt }],
       });
       const block = response.content[0];

--- a/src/llm/providers/gemini.ts
+++ b/src/llm/providers/gemini.ts
@@ -1,11 +1,17 @@
 // Google Gemini provider implementation
 
 import { GoogleGenerativeAI } from "@google/generative-ai";
-import type { LLMProvider, LLMConfig } from "../types.js";
+import { DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE, type LLMProvider, type LLMConfig } from "../types.js";
 
 export const createGeminiProvider = (config: LLMConfig): LLMProvider => {
   const genAI = new GoogleGenerativeAI(config.apiKey);
-  const model = genAI.getGenerativeModel({ model: config.model });
+  const model = genAI.getGenerativeModel({
+    model: config.model,
+    generationConfig: {
+      maxOutputTokens: DEFAULT_MAX_TOKENS,
+      temperature: DEFAULT_TEMPERATURE,
+    },
+  });
 
   return {
     generate: async (prompt: string): Promise<string> => {

--- a/src/renderer/helpers.ts
+++ b/src/renderer/helpers.ts
@@ -110,4 +110,8 @@ export const registerHelpers = (
   hbs.registerHelper("neq", function (this: unknown, a: unknown, b: unknown, opts: Handlebars.HelperOptions) {
     return a !== b ? opts.fn(this) : opts.inverse(this);
   });
+
+  hbs.registerHelper("urlEncode", (text: string): string =>
+    encodeURIComponent(String(text ?? "")),
+  );
 };

--- a/src/renderer/templates/report.hbs
+++ b/src/renderer/templates/report.hbs
@@ -83,9 +83,9 @@
 {{#if canonicalUrl}}
 <div class="share-bar">
   <span class="share-label">{{i18n.share}}</span>
-  <a href="https://x.com/intent/tweet?url={{{canonicalUrl}}}&text={{aiContent.title}}" target="_blank" rel="noopener nofollow" class="share-btn share-x" aria-label="Share on X">𝕏</a>
+  <a href="https://x.com/intent/tweet?url={{{canonicalUrl}}}&text={{urlEncode aiContent.title}}" target="_blank" rel="noopener nofollow" class="share-btn share-x" aria-label="Share on X">𝕏</a>
   <a href="https://www.linkedin.com/sharing/share-offsite/?url={{{canonicalUrl}}}" target="_blank" rel="noopener nofollow" class="share-btn share-linkedin" aria-label="Share on LinkedIn">in</a>
-  <a href="https://bsky.app/intent/compose?text={{aiContent.title}}%20{{{canonicalUrl}}}" target="_blank" rel="noopener nofollow" class="share-btn share-bsky" aria-label="Share on Bluesky">🦋</a>
+  <a href="https://bsky.app/intent/compose?text={{urlEncode aiContent.title}}%20{{{canonicalUrl}}}" target="_blank" rel="noopener nofollow" class="share-btn share-bsky" aria-label="Share on Bluesky">🦋</a>
 </div>
 {{/if}}
 


### PR DESCRIPTION
## Summary

- Comprehensive UX audit and fixes for first-time user experience
- Error handling improvements to prevent silent failures
- i18n corrections and LLM provider consistency fixes

## Changes

### Error Handling (High Impact)
- **Events API 401/403 now throws** instead of silently returning empty results. Users with invalid/expired tokens will see a clear error instead of "Fetched 0 events"
- **Events API 429 retry**: rate-limited requests are retried with backoff (up to 3 attempts) using `retry-after` header
- **Search API 401/403 throws**, other errors warn and continue
- **Model validation false-positive fixed**: matching `"not found"` instead of `"model"` in error body. Prevents transient errors ("model is overloaded") from being misreported as "model not found"
- **300-event limit warning**: notifies when GitHub Events API page limit is reached
- **PR fetch failure summary**: logs "N of M PRs could not be fetched" after batch fetch

### Setup UX
- **Spinner added** for token and model validation (no external deps, TTY-aware)
- **403 permission hint** on `addFileToRepo` failure: suggests which PAT permissions to check
- **Site title `\n` display**: CLI summary and generated README show space instead of raw `\n`
- **DST cron fix**: uses Jan 1 (standard time) offset instead of current time, preventing daily-fetch from running at 23:00 local (wrong day) during DST transitions

### Documentation
- **README PAT section**: documents both fine-grained (recommended) and classic PAT options
- **`render --language` help**: lists all 10 supported languages instead of just "en, ja"

### LLM
- **Anthropic**: added `temperature: 0.7` (was using provider default 1.0)
- **Gemini**: added `maxOutputTokens: 16384` and `temperature: 0.7` (was using provider defaults)
- **YAML parse error hint**: error message now suggests retrying or trying a different model

### i18n
- **French**: Résumé, précédente, éléments
- **German**: Nächste, Einträge
- **Portuguese**: Próxima, Relatórios, Relatório, seções, Sáb
- **Spanish**: Mié, Sáb

### Other
- **`urlEncode` Handlebars helper**: share links (X, Bluesky) now properly encode AI-generated titles

## Testing

All 491 tests pass. Build and lint clean.