### PR TITLE
fix: compute correct UTC day-of-week for weekly cron in east-of-UTC timezones

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -59,7 +59,7 @@ Two things must be updated:
    | Asia/Tokyo (UTC+9) | `0 15 * * *` |
    | Asia/Shanghai (UTC+8) | `0 16 * * *` |
 
-   The weekly cron should be 1 hour after the daily cron, on Mondays only. For example, if the daily cron is `0 15 * * *`, the weekly cron is `0 16 * * 1`.
+   The weekly cron should be 1 hour after the daily cron, on the UTC day-of-week that corresponds to Monday in your timezone. For example, if the daily cron is `0 15 * * *` (Asia/Tokyo), the weekly cron is `0 16 * * 0` (Sunday in UTC = Monday 01:00 in JST).
 
 ## LLM Provider and Model
 

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -69,8 +69,8 @@ name: Weekly Report
 
 on:
   schedule:
-    # Run Monday, 1 hour after daily fetch (this example is 01:00 JST = 16:00 UTC)
-    - cron: '0 16 * * 1'
+    # Run Monday, 1 hour after daily fetch (this example is Mon 01:00 JST = Sun 16:00 UTC)
+    - cron: '0 16 * * 0'
   workflow_dispatch:
 
 permissions:

--- a/src/cli/commands/setup/workflows.test.ts
+++ b/src/cli/commands/setup/workflows.test.ts
@@ -1,5 +1,45 @@
 import { describe, it, expect } from "vitest";
-import { buildReadme } from "./workflows.js";
+import { buildReadme, weeklyCronUTC } from "./workflows.js";
+
+describe("weeklyCronUTC", () => {
+  // day-of-week: 0=Sunday, 1=Monday
+  // For east-of-UTC timezones, local Monday 01:00 falls on UTC Sunday,
+  // so day-of-week should be 0.
+
+  it("returns Monday (1) for UTC", () => {
+    expect(weeklyCronUTC("UTC")).toBe("0 1 * * 1");
+  });
+
+  it("returns Sunday (0) for Asia/Tokyo (UTC+9)", () => {
+    // daily: 0 15 * * *, weekly: Mon 01:00 JST = Sun 16:00 UTC
+    expect(weeklyCronUTC("Asia/Tokyo")).toBe("0 16 * * 0");
+  });
+
+  it("returns Monday (1) for America/New_York (UTC-5)", () => {
+    // daily: 0 5 * * *, weekly: Mon 01:00 EST = Mon 06:00 UTC
+    expect(weeklyCronUTC("America/New_York")).toBe("0 6 * * 1");
+  });
+
+  it("returns Monday (1) for America/Los_Angeles (UTC-8)", () => {
+    // daily: 0 8 * * *, weekly: Mon 01:00 PST = Mon 09:00 UTC
+    expect(weeklyCronUTC("America/Los_Angeles")).toBe("0 9 * * 1");
+  });
+
+  it("returns Sunday (0) for Asia/Shanghai (UTC+8)", () => {
+    // daily: 0 16 * * *, weekly: Mon 01:00 CST = Sun 17:00 UTC
+    expect(weeklyCronUTC("Asia/Shanghai")).toBe("0 17 * * 0");
+  });
+
+  it("returns Monday (1) for Europe/Berlin (UTC+1, standard time)", () => {
+    // daily: 0 23 * * *, weekly: Mon 01:00 CET = Mon 00:00 UTC
+    expect(weeklyCronUTC("Europe/Berlin")).toBe("0 0 * * 1");
+  });
+
+  it("returns Sunday (0) for Pacific/Auckland (UTC+13)", () => {
+    // daily: 0 11 * * *, weekly: Mon 01:00 NZDT = Sun 12:00 UTC
+    expect(weeklyCronUTC("Pacific/Auckland")).toBe("0 12 * * 0");
+  });
+});
 
 describe("buildReadme", () => {
   const baseOpts = {

--- a/src/cli/commands/setup/workflows.ts
+++ b/src/cli/commands/setup/workflows.ts
@@ -91,12 +91,35 @@ jobs:
 `;
 };
 
-export const buildWeeklyWorkflow = (opts: WorkflowOpts): string => {
-  // Run 1 hour after daily fetch, Monday only
-  const dailyCron = midnightCronUTC(opts.timezone);
+export const weeklyCronUTC = (timezone: string): string => {
+  // Weekly report runs 1 hour after daily fetch, on the local Monday.
+  // Because cron is in UTC, the UTC day-of-week may differ from the
+  // local day-of-week for timezones with positive offsets (e.g.
+  // Asia/Tokyo local Monday 01:00 = UTC Sunday 16:00, day-of-week 0).
+  const dailyCron = midnightCronUTC(timezone);
   const [minute, hour] = dailyCron.split(" ").map(Number);
   const weeklyHour = (hour + 1) % 24;
-  const weeklyCron = `${minute} ${weeklyHour} * * 1`;
+  // Compute tz offset: positive = local is ahead of UTC (e.g. +540 for Asia/Tokyo).
+  const jan1 = new Date(new Date().getFullYear(), 0, 1, 0, 0, 0);
+  const utcMidnight = new Date(
+    jan1.toLocaleString("en-US", { timeZone: "UTC" }),
+  );
+  const localMidnight = new Date(
+    jan1.toLocaleString("en-US", { timeZone: timezone }),
+  );
+  const offsetMinutes = Math.round(
+    (localMidnight.getTime() - utcMidnight.getTime()) / 60000,
+  );
+  // Local Monday 01:00 is 60 minutes after Monday 00:00 local.
+  // In UTC that is (60 - offsetMinutes) minutes from Monday 00:00 UTC.
+  const utcMinutesFromMondayStart = 60 - offsetMinutes;
+  const dayShift = Math.floor(utcMinutesFromMondayStart / (24 * 60));
+  const utcDow = (((1 + dayShift) % 7) + 7) % 7;
+  return `${minute} ${weeklyHour} * * ${utcDow}`;
+};
+
+export const buildWeeklyWorkflow = (opts: WorkflowOpts): string => {
+  const weeklyCron = weeklyCronUTC(opts.timezone);
 
   const llmInputs =
     opts.llmProvider && opts.llmModel && opts.llmSecretName


### PR DESCRIPTION
## Summary

- Fix weekly cron day-of-week calculation that was hard-coded to `1` (Monday UTC), causing reports to fire on **Tuesday local time** for east-of-UTC timezones (e.g. Asia/Tokyo `0 16 * * 1` = JST Tuesday 01:00, not Monday).
- Extract `weeklyCronUTC()` function that derives the correct UTC day-of-week from the timezone offset (e.g. Asia/Tokyo now produces `0 16 * * 0`, which is Sunday UTC = Monday 01:00 JST).
- Fix example cron values in `docs/manual-setup.md` and `docs/customization.md`.
- Add 7 test cases for `weeklyCronUTC` covering UTC, Asia/Tokyo, America/New_York, America/Los_Angeles, Asia/Shanghai, Europe/Berlin, and Pacific/Auckland.